### PR TITLE
fix(plugin): Container logs: Exclude bindplane-agent logs by default

### DIFF
--- a/docs/plugins/container_logs.md
+++ b/docs/plugins/container_logs.md
@@ -9,7 +9,7 @@ Log parser for Kubernetes Container logs. This plugin is meant to be used with t
 | log_source | Where to read container logs from | string | `file` | false | `file`, `journald` |
 | log_paths | A list of file glob patterns that match the file paths to be read | []string | `[/var/log/containers/*.log]` | false |  |
 | journald_path | The path to read journald container logs from | string | `/var/log/journal` | false |  |
-| exclude_file_log_path | A list of file glob patterns to exclude from reading | []string | `[/var/log/containers/observiq-*-collector-*]` | false |  |
+| exclude_file_log_path | A list of file glob patterns to exclude from reading | []string | `[/var/log/containers/observiq-*-collector-* /var/log/containers/bindplane-*-agent-*]` | false |  |
 | body_json_parsing | If the application log is detected as json, parse the values into the log entry's body. | bool | `true` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | log_driver | The container runtime's log driver used to write container logs to disk. Valid options include `auto`, `docker-json-file` and `containerd-cri`. When set to `auto`, the format will be detected using regex. Format detection is convenient but comes with the cost of performing a regex match against every log entry read by the filelog receiver. | string | `auto` | false | `auto`, `docker-json-file`, `containerd-cri` |
@@ -27,7 +27,7 @@ receivers:
       log_source: file
       log_paths: [/var/log/containers/*.log]
       journald_path: /var/log/journal
-      exclude_file_log_path: [/var/log/containers/observiq-*-collector-*]
+      exclude_file_log_path: [/var/log/containers/observiq-*-collector-* /var/log/containers/bindplane-*-agent-*]
       body_json_parsing: true
       start_at: end
       log_driver: auto

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.5.0
+version: 0.5.1
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -24,6 +24,7 @@ parameters:
     default:
       # Excludes logs for the collector
       - "/var/log/containers/observiq-*-collector-*"
+      - "/var/log/containers/bindplane-*-agent-*"
   - name: body_json_parsing
     type: bool
     description: If the application log is detected as json, parse the values into the log entry's body.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

BindPlane deploys the agent with the pod name `bindplane-node-agent-*` and `bindplane-cluster-agent-*`. These pods should be excluded by default, to prevent circular logging.

Using BindPlane, I can see the agent's logs by filtering on `k8s.namespace.name: bindplane-agent`:

![Screenshot from 2023-07-21 18-19-43](https://github.com/observIQ/bindplane-agent/assets/23043836/2e953eec-0de9-4b2d-92d9-7b9699c44786)

![Screenshot from 2023-07-21 18-25-31](https://github.com/observIQ/bindplane-agent/assets/23043836/13314965-8187-4bc3-a5fc-48c6d573c3eb)

To simulate this change, I had to update the source configuration with the same exclusion:

![Screenshot from 2023-07-21 18-31-07](https://github.com/observIQ/bindplane-agent/assets/23043836/4205569f-541f-4222-8ab0-71332882b57d)

With the filter in place, and the exclusion, the agent is reporting zero logs (as expected).

##### Checklist
- [x] Changes are tested
- [x] CI has passed
