### PR TITLE
fix: When shutting down on windows, set a max timeout of 20 seconds

### DIFF
--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -158,7 +158,7 @@ func (sh windowsServiceHandler) shutdown(s chan<- svc.Status) error {
 	var err error
 	select {
 	case <-time.After(windowsServiceShutdownTimeout):
-		err = errors.New("the service failed to shut down in a timely manner")
+		err = fmt.Errorf("the service failed to shut down in a timely manner (timeout: %s)", windowsServiceShutdownTimeout)
 	case stopErr := <-stopErrChan:
 		err = stopErr
 	}

--- a/updater/internal/logging/logging_others.go
+++ b/updater/internal/logging/logging_others.go
@@ -36,6 +36,7 @@ func NewLogger(installDir string) (*zap.Logger, error) {
 		logFile,
 	}
 	conf.Level.SetLevel(zapcore.DebugLevel)
+	conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	err := os.RemoveAll(logFile)
 	if err != nil {

--- a/updater/internal/logging/logging_windows.go
+++ b/updater/internal/logging/logging_windows.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/observiq/bindplane-agent/updater/internal/path"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var registerSinkOnce = &sync.Once{}
@@ -51,6 +52,8 @@ func NewLogger(installDir string) (*zap.Logger, error) {
 	conf.OutputPaths = []string{
 		"winfile:///" + logFile,
 	}
+	conf.Level.SetLevel(zapcore.DebugLevel)
+	conf.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	prodLogger, err := conf.Build()
 	if err != nil {

--- a/updater/internal/service/testdata/test-windows-service.go
+++ b/updater/internal/service/testdata/test-windows-service.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"golang.org/x/sys/windows/svc"
 )
@@ -47,6 +48,7 @@ func (sh *windowsService) Execute(args []string, r <-chan svc.ChangeRequest, s c
 		case svc.Interrogate:
 			s <- req.CurrentStatus
 		case svc.Stop, svc.Shutdown:
+			time.Sleep(5 * time.Second)
 			return false, 0
 		default:
 			return false, 1052


### PR DESCRIPTION
### Proposed Change
* When shutting down, we cap the time for stopping to 20 seconds
  * This fixes issues where shutting down the service can be unresponsive, and you get an error message in Service Manager
  * This fixes an issue where the process living too long can cause the update process to fail on windows.
* Wait for the windows service to actually be stopped in the update logic
  * This patches a race condition in the update path, where the collector may fail to properly update if the process is not actually stopped by the time it tries to overwrite to collector binary
* Update the updater logging for windows to match Linux, and use ISO8601 timestamps instead of unix timestamps.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
