### PR TITLE
chore: Updated linter rules to add struct-tag and time-equal

### DIFF
--- a/revive/config.toml
+++ b/revive/config.toml
@@ -28,3 +28,5 @@ warningCode = 1
 [rule.unused-parameter]
 [rule.unreachable-code]
 [rule.redefines-builtin-id]
+[rule.struct-tag]
+[rule.time-equal]


### PR DESCRIPTION
### Proposed Change
Updated linter to rules to add [struct-tag](https://github.com/mgechev/revive/blob/v1.3.2/RULES_DESCRIPTIONS.md#struct-tag) and [time-equal](https://github.com/mgechev/revive/blob/v1.3.2/RULES_DESCRIPTIONS.md#time-equal)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
