### PR TITLE
Pass Version into OpAMP Client

### DIFF
--- a/internal/service/managed.go
+++ b/internal/service/managed.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/observiq/bindplane-agent/collector"
+	"github.com/observiq/bindplane-agent/internal/version"
 	"github.com/observiq/bindplane-agent/opamp"
 	"github.com/observiq/bindplane-agent/opamp/observiq"
 	"go.uber.org/zap"
@@ -48,6 +49,7 @@ func NewManagedCollectorService(col collector.Collector, logger *zap.Logger, man
 		DefaultLogger:       logger,
 		Config:              *opampConfig,
 		Collector:           col,
+		Version:             version.Version(),
 		TmpPath:             "./tmp",
 		ManagerConfigPath:   managerConfigPath,
 		CollectorConfigPath: collectorConfigPath,

--- a/opamp/observiq/identity.go
+++ b/opamp/observiq/identity.go
@@ -18,7 +18,6 @@ import (
 	"runtime"
 
 	ios "github.com/observiq/bindplane-agent/internal/os"
-	"github.com/observiq/bindplane-agent/internal/version"
 	"github.com/observiq/bindplane-agent/opamp"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.uber.org/zap"
@@ -39,7 +38,7 @@ type identity struct {
 }
 
 // newIdentity constructs a new identity for this collector
-func newIdentity(logger *zap.Logger, config opamp.Config) *identity {
+func newIdentity(logger *zap.Logger, config opamp.Config, version string) *identity {
 	// Grab various fields from OS
 	hostname, err := ios.Hostname()
 	if err != nil {
@@ -55,7 +54,7 @@ func newIdentity(logger *zap.Logger, config opamp.Config) *identity {
 		agentID:     config.AgentID,
 		agentName:   config.AgentName,
 		serviceName: "com.observiq.collector", // Hardcoded defines this type of agent to the server
-		version:     version.Version(),
+		version:     version,
 		labels:      config.Labels,
 		oSArch:      runtime.GOARCH,
 		oSDetails:   name,

--- a/opamp/observiq/identity_test.go
+++ b/opamp/observiq/identity_test.go
@@ -18,7 +18,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/observiq/bindplane-agent/internal/version"
 	"github.com/observiq/bindplane-agent/opamp"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +38,9 @@ func Test_newIdentity(t *testing.T) {
 		AgentName: &agentNameContents,
 	}
 
-	got := newIdentity(zap.NewNop(), cfg)
+	expectedVersion := "0.0.0"
+
+	got := newIdentity(zap.NewNop(), cfg, expectedVersion)
 
 	// Check all fields from config
 	require.Equal(t, cfg.AgentID, got.agentID)
@@ -53,7 +54,7 @@ func Test_newIdentity(t *testing.T) {
 
 	// Check hardcoded/fields from runtime and other packages
 	require.Equal(t, got.serviceName, "com.observiq.collector")
-	require.Equal(t, got.version, version.Version())
+	require.Equal(t, got.version, expectedVersion)
 	require.Equal(t, got.oSArch, runtime.GOARCH)
 	require.Equal(t, got.oSFamily, runtime.GOOS)
 }

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -73,6 +73,7 @@ type NewClientArgs struct {
 	DefaultLogger *zap.Logger
 	Config        opamp.Config
 	Collector     collector.Collector
+	Version       string
 
 	TmpPath             string
 	ManagerConfigPath   string
@@ -104,7 +105,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 
 	observiqClient := &Client{
 		logger:                  clientLogger,
-		ident:                   newIdentity(clientLogger, args.Config),
+		ident:                   newIdentity(clientLogger, args.Config, args.Version),
 		configManager:           configManager,
 		downloadableFileManager: newDownloadableFileManager(clientLogger, args.TmpPath),
 		collector:               args.Collector,

--- a/opamp/observiq/reload_funcs_test.go
+++ b/opamp/observiq/reload_funcs_test.go
@@ -93,7 +93,7 @@ func Test_managerReload(t *testing.T) {
 
 				client := &Client{
 					opampClient:   mockOpAmpClient,
-					ident:         newIdentity(zap.NewNop(), *currConfig),
+					ident:         newIdentity(zap.NewNop(), *currConfig, "0.0.0"),
 					currentConfig: *currConfig,
 				}
 				reloadFunc := managerReload(client, managerFilePath)
@@ -148,7 +148,7 @@ func Test_managerReload(t *testing.T) {
 
 				client := &Client{
 					opampClient:   mockOpAmpClient,
-					ident:         newIdentity(zap.NewNop(), *currConfig),
+					ident:         newIdentity(zap.NewNop(), *currConfig, "0.0.0"),
 					currentConfig: *currConfig,
 				}
 				reloadFunc := managerReload(client, managerFilePath)


### PR DESCRIPTION
### Proposed Change
Modified to pass the version into the OpAMP client rather than pulling it from the version package. This way we can easily set collector version in Amplify scaling tool.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
