### PR TITLE
fix: Reset Component Telemetry on a managed mode reconfigure

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -98,6 +98,11 @@ func (c *collector) Run(ctx context.Context) error {
 		return errors.New("service already running")
 	}
 
+	// Register component telemetry before running to ensure a clean state for this run
+	if err := factories.RegisterComponentTelemetry(); err != nil {
+		return fmt.Errorf("register component telemetry: %w", err)
+	}
+
 	// The OT collector only supports using settings once during the lifetime
 	// of a single collector instance. We must remake the settings on each startup.
 	settings, err := NewSettings(c.configPaths, c.version, c.loggingOpts, c.factories)


### PR DESCRIPTION
### Proposed Change
Fixes an issue where component telemetry (specifically the throughputmeasurement processor) would not reset and clear out on a hot reload reconfigure in managed mode.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
