### PR TITLE
feat: Add filelog.mtimeSortType feature flag

### DIFF
--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -28,5 +28,9 @@ func SetFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.allowHeaderMetadataParsing", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.allowHeaderMetadataParsing: %w", err)
 	}
+	if err := featuregate.GlobalRegistry().Set("filelog.mtimeSortType", true); err != nil {
+		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Proposed Change
* Adds the `filelog.mtimeSortType` feature flag, which enables using the `mtime` sort type in the filelog's `ordering_criteria` section.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
