### PR TITLE
feat(service): SysV init.d style startup script

### DIFF
--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -36,9 +36,9 @@ start() {
   else
     echo " * Starting $PROGRAM"
     if [ $DEBUG ]; then
-    COMMAND=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1> /dev/null 2>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log
+      COMMAND='"/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1> /dev/null 2>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log'
     else
-    COMMAND=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log 2>&1
+      COMMAND='"/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log 2>&1'
     fi
     export OIQ_OTEL_COLLECTOR_HOME
     export OIQ_OTEL_COLLECTOR_STORAGE

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -27,7 +27,7 @@ HTTP_PROXY=
 HTTPS_PROXY=
 # set this to a user such as observiq-otel-collector, to run as that user
 # observiq-otel-collector user is created during installation
-# leave this variable empty to run as root
+# leave this variable empty to run as root (Default behavior)
 RUNUSER=
 PIDFILE=/var/run/observiq-otel-collector.pid
 DEBUG=false

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -25,7 +25,9 @@ OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 HTTP_PROXY=
 HTTPS_PROXY=
-USER=root
+# set this to a user such as observiq-otel-collector, to run as that user
+# observiq-otel-collector user is created during installation
+USER=
 PIDFILE=/var/run/observiq-otel-collector.pid
 DEBUG=false
 RETVAL=0

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -48,7 +48,7 @@ start() {
     export HTTP_PROXY
     export HTTPS_PROXY
     if [ -n "$RUNUSER" ]; then
-      su -p $RUNUSER -c "$COMMAND" &
+      su -p "$RUNUSER" -c "$COMMAND" &
     else
       nohup "$COMMAND" &
     fi

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -25,6 +25,7 @@ OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 HTTP_PROXY=
 HTTPS_PROXY=
+USER=root
 PIDFILE=/var/run/observiq-otel-collector.pid
 DEBUG=false
 RETVAL=0
@@ -36,20 +37,22 @@ start() {
   else
     echo " * Starting $PROGRAM"
     if [ $DEBUG ]; then
-      COMMAND='"/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1> /dev/null 2>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log'
+      COMMAND="cd /opt/observiq-otel-collector/ && nohup /opt/observiq-otel-collector/observiq-otel-collector --config config.yaml 1> /dev/null 2>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log"
     else
-      COMMAND='"/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log 2>&1'
+      COMMAND="cd /opt/observiq-otel-collector/ && nohup /opt/observiq-otel-collector/observiq-otel-collector --config config.yaml 1>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log 2>&1"
     fi
     export OIQ_OTEL_COLLECTOR_HOME
     export OIQ_OTEL_COLLECTOR_STORAGE
     export HTTP_PROXY
     export HTTPS_PROXY
-    if [ -n "root" ]; then
-    su -p root -c "cd /opt/observiq-otel-collector/ && nohup $COMMAND &
+    if [ -n "$USER" ]; then
+      su -p $USER -c "$COMMAND" &
     else
-    nohup "cd /opt/observiq-otel-collector/ && nohup $COMMAND &
+      nohup "$COMMAND" &
     fi
     echo $! > $PIDFILE
+    # disabling shellcheck due to this being the one documented exception. See https://www.shellcheck.net/wiki/SC2320
+    # shellcheck disable=SC2320
     RETVAL=$?
     [ "$RETVAL" -eq 0 ] && touch $LOCKFILE
   fi
@@ -58,8 +61,8 @@ start() {
 stop() {
   if [ -f $PIDFILE ]; then
     PID=$(cat $PIDFILE);
-    printf " * Stopping $PROGRAM... "
-    kill $PID > /dev/null 2>&1
+    printf " * Stopping %s... " "$PROGRAM"
+    kill "$PID" > /dev/null 2>&1
     echo "stopped"
     rm $PIDFILE && rm -f $LOCKFILE
     RETVAL=0
@@ -71,6 +74,10 @@ stop() {
 
 pid_status() {
   if [ -e "$PIDFILE" ]; then
+    # disabling this shellcheck due to needing legacy support on some systems
+    # shellcheck disable=SC2006
+    # disabling this shellcheck due to incorrect detection
+    # shellcheck disable=SC2046
     echo " * $PROGRAM" is running, pid=`cat "$PIDFILE"`
     RETVAL=0
   else
@@ -80,10 +87,10 @@ pid_status() {
 }
 
 otel_status() {
-  if [ $PROC ]; then
+  if [ "$PROC" ]; then
     status_of_proc -p $PIDFILE "$PROGRAM" "$PROGRAM"
     RETVAL=$?
-  elif [ $STATUS ]; then
+  elif [ "$STATUS" ]; then
     status -p $PIDFILE $PROGRAM
     RETVAL=$?
   else

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -27,7 +27,7 @@ HTTP_PROXY=
 HTTPS_PROXY=
 # set this to a user such as observiq-otel-collector, to run as that user
 # observiq-otel-collector user is created during installation
-USER=
+RUNUSER=
 PIDFILE=/var/run/observiq-otel-collector.pid
 DEBUG=false
 RETVAL=0
@@ -47,8 +47,8 @@ start() {
     export OIQ_OTEL_COLLECTOR_STORAGE
     export HTTP_PROXY
     export HTTPS_PROXY
-    if [ -n "$USER" ]; then
-      su -p $USER -c "$COMMAND" &
+    if [ -n "$RUNUSER" ]; then
+      su -p $RUNUSER -c "$COMMAND" &
     else
       nohup "$COMMAND" &
     fi

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -1,0 +1,114 @@
+#!/bin/sh
+# observIQ OTEL daemon
+# chkconfig: 2345 99 05
+# description: observIQ's distribution of the OpenTelemetry collector
+# processname: observiq-otel-collector
+# pidfile: /var/run/observiq-otel-collector.pid
+
+# Source function library.
+if [ -e /etc/init.d/functions ]; then
+  STATUS=true
+  . /etc/init.d/functions
+fi
+
+if [ -e /lib/lsb/init-functions ]; then
+  PROC=true
+  . /lib/lsb/init-functions
+fi
+
+# Pull in sysconfig settings
+[ -f /etc/sysconfig/observiq-otel-collector ] && . /etc/sysconfig/observiq-otel-collector
+
+PROGRAM=observiq-otel-collector
+LOCKFILE=/var/lock/$PROGRAM
+OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
+OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
+HTTP_PROXY=
+HTTPS_PROXY=
+PIDFILE=/var/run/observiq-otel-collector.pid
+DEBUG=false
+RETVAL=0
+start() {
+  if [ -f $PIDFILE ]; then
+    PID=$(cat $PIDFILE)
+    echo " * $PROGRAM already running: $PID"
+    RETVAL=2
+  else
+    echo " * Starting $PROGRAM"
+    if [ $DEBUG ]; then
+    COMMAND=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1> /dev/null 2>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log
+    else
+    COMMAND=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml" 1>> $OIQ_OTEL_COLLECTOR_HOME/log/error.log 2>&1
+    fi
+    export OIQ_OTEL_COLLECTOR_HOME
+    export OIQ_OTEL_COLLECTOR_STORAGE
+    export HTTP_PROXY
+    export HTTPS_PROXY
+    if [ -n "root" ]; then
+    su -p root -c "cd /opt/observiq-otel-collector/ && nohup $COMMAND &
+    else
+    nohup "cd /opt/observiq-otel-collector/ && nohup $COMMAND &
+    fi
+    echo $! > $PIDFILE
+    RETVAL=$?
+    [ "$RETVAL" -eq 0 ] && touch $LOCKFILE
+  fi
+}
+
+stop() {
+  if [ -f $PIDFILE ]; then
+    PID=$(cat $PIDFILE);
+    printf " * Stopping $PROGRAM... "
+    kill $PID > /dev/null 2>&1
+    echo "stopped"
+    rm $PIDFILE && rm -f $LOCKFILE
+    RETVAL=0
+  else
+    echo " * $PROGRAM is not running"
+    RETVAL=3
+  fi
+}
+
+pid_status() {
+  if [ -e "$PIDFILE" ]; then
+    echo " * $PROGRAM" is running, pid=`cat "$PIDFILE"`
+    RETVAL=0
+  else
+    echo " * $PROGRAM is not running"
+    RETVAL=1
+  fi
+}
+
+otel_status() {
+  if [ $PROC ]; then
+    status_of_proc -p $PIDFILE "$PROGRAM" "$PROGRAM"
+    RETVAL=$?
+  elif [ $STATUS ]; then
+    status -p $PIDFILE $PROGRAM
+    RETVAL=$?
+  else
+    pid_status
+  fi
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    otel_status
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: {start|stop|status|restart}"
+    RETVAL=3
+    ;;
+esac
+
+exit $RETVAL

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -27,6 +27,7 @@ HTTP_PROXY=
 HTTPS_PROXY=
 # set this to a user such as observiq-otel-collector, to run as that user
 # observiq-otel-collector user is created during installation
+# leave this variable empty to run as root
 RUNUSER=
 PIDFILE=/var/run/observiq-otel-collector.pid
 DEBUG=false


### PR DESCRIPTION
### Proposed Change
This startup script will be needed to support any Linux distros that aren't using systemd. This is mostly older distros, but some modern tiny distros still use init.d scripts as well.

Known issues/concerns to be addressed in a future PR:
- error.log doesn't get rotated (still researching best way to do this)
- Has only been tested on EL6. Needs to be tested on SLES11, and a modern tiny distro as well.

- [X] Changes are tested
- [ ] CI has passed
