### PR TITLE
fix(httpreceiver): Fix double wrapped TLS listener

### DIFF
--- a/receiver/httpreceiver/logs.go
+++ b/receiver/httpreceiver/logs.go
@@ -77,31 +77,15 @@ func (r *httpLogsReceiver) startListening(host component.Host) error {
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
+		r.logger.Debug("starting to serve",
+			zap.String("address", r.serverSettings.Endpoint),
+		)
 
-		if r.serverSettings.TLSSetting != nil {
-			r.logger.Debug("starting ServeTLS",
-				zap.String("address", r.serverSettings.Endpoint),
-				zap.String("cert_file", r.serverSettings.TLSSetting.CertFile),
-				zap.String("key_file", r.serverSettings.TLSSetting.KeyFile),
-			)
-
-			err := r.server.ServeTLS(listener, r.serverSettings.TLSSetting.CertFile, r.serverSettings.TLSSetting.KeyFile)
-			r.logger.Debug("ServeTLS done")
-			if err != http.ErrServerClosed {
-				r.logger.Error("ServeTLS failed", zap.Error(err))
-				host.ReportFatalError(err)
-			}
-		} else {
-			r.logger.Debug("starting to serve",
-				zap.String("address", r.serverSettings.Endpoint),
-			)
-
-			err := r.server.Serve(listener)
-			r.logger.Debug("Serve done")
-			if err != http.ErrServerClosed {
-				r.logger.Error("Serve failed", zap.Error(err))
-				host.ReportFatalError(err)
-			}
+		err := r.server.Serve(listener)
+		r.logger.Debug("Serve done")
+		if err != http.ErrServerClosed {
+			r.logger.Error("Serve failed", zap.Error(err))
+			host.ReportFatalError(err)
 		}
 	}()
 


### PR DESCRIPTION
### Proposed Change
* Always use http.Server.Serve instead of http.Server.ServeTLS

The listener returned from `serverSettings.ToListener` will already have TLS built in, so it strips any TLS handshake stuff before it reaches the server. Since it's double wrapped due to ServerTLS, the inner TLS handler doesn't see the handshake, and always assumes it's just getting a normal http request, even when sending an https request.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
