### PR TITLE
feat(ppc-linux): Add PowerPC architectures for Linux OS Releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,15 +21,25 @@ builds:
       - arm64
       - arm
       - "386"
+      - ppc64
+      - ppc64le
     ignore:
       - goos: windows
         goarch: arm
       - goos: windows
         goarch: arm64
+      - goos: windows
+        goarch: ppc64
+      - goos: windows
+        goarch: ppc64le
       - goos: linux
         goarch: "386"
       - goos: darwin
         goarch: "386"
+      - goos: darwin
+        goarch: ppc64
+      - goos: darwin
+        goarch: ppc64le
     ldflags:
       - -s -w
       - -X github.com/observiq/bindplane-agent/internal/version.version=v{{ .Version }}
@@ -52,15 +62,25 @@ builds:
       - arm64
       - arm
       - "386"
+      - ppc64
+      - ppc64le
     ignore:
       - goos: windows
         goarch: arm
       - goos: windows
         goarch: arm64
+      - goos: windows
+        goarch: ppc64
+      - goos: windows
+        goarch: ppc64le
       - goos: linux
         goarch: "386"
       - goos: darwin
         goarch: "386"
+      - goos: darwin
+        goarch: ppc64
+      - goos: darwin
+        goarch: ppc64le
     ldflags:
       - -s -w
       - -X github.com/observiq/bindplane-agent/updater/internal/version.version=v{{ .Version }}

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,21 @@ build-binaries: agent updater
 build-all: build-linux build-darwin build-windows
 
 .PHONY: build-linux
-build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm
+build-linux: build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-ppc64 build-linux-ppc64le
 
 .PHONY: build-darwin
 build-darwin: build-darwin-amd64 build-darwin-arm64
 
 .PHONY: build-windows
 build-windows: build-windows-amd64 build-windows-x86
+
+.PHONY: build-linux-ppc64
+build-linux-ppc64:
+	GOOS=linux GOARCH=ppc64 $(MAKE) build-binaries -j2
+
+.PHONY: build-linux-ppc64le
+build-linux-ppc64le:
+	GOOS=linux GOARCH=ppc64le $(MAKE) build-binaries -j2
 
 .PHONY: build-linux-amd64
 build-linux-amd64:

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -355,6 +355,13 @@ set_os_arch()
     x86_64)
       os_arch="amd64"
       ;;
+    # experimental PowerPC arch support for collector
+    ppc64)
+      os_arch="ppc64"
+      ;;
+    ppc64le)
+      os_arch="ppc64le"
+      ;;
     # armv6/32bit. These are what raspberry pi can return, which is the main reason we support 32-bit arm
     arm|armv6l|armv7l)
       os_arch="arm"
@@ -533,7 +540,7 @@ os_arch_check()
   info "Checking for valid operating system architecture..."
   arch=$(uname -m)
   case "$arch" in 
-    x86_64|aarch64|arm64|aarch64_be|armv8b|armv8l|arm|armv6l|armv7l)
+    x86_64|aarch64|ppc64|ppc64le|arm64|aarch64_be|armv8b|armv8l|arm|armv6l|armv7l)
       succeeded
       ;;
     *)


### PR DESCRIPTION
### Proposed Change
This PR will introduce PowerPC (ppc64 and ppc64le) Linux build and release artifacts. These have been tested on an Enterprise Linux ppc64le system.

Access for testing can be provided. The test system is running on SiteOx, and we rented it only for a month.

##### Checklist
- [X] Changes are tested
- [x] CI has passed
