### PR TITLE
feat(install_scripts): Check BindPlane URL before installing

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -286,7 +286,7 @@ connection_check()
       HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed 's#^ws#http#' | sed 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
-      if curl -s "${HTTP_ENDPOINT}" > /dev/null; then
+      if curl --max-time 20 -s "${HTTP_ENDPOINT}" > /dev/null; then
         succeeded
       else
         failed

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -73,7 +73,7 @@ printf() {
 }
 
 increase_indent() { indent="$INDENT_WIDTH$indent" ; }
-decrease_indent() { indent="${indent#*$INDENT_WIDTH}" ; }
+decrease_indent() { indent="${indent#*"$INDENT_WIDTH"}" ; }
 
 # Color functions reset only when given an argument
 bold() { command printf "$bold$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
@@ -281,19 +281,18 @@ check_prereqs()
 # Test connection to BindPlane if it was specified
 connection_check()
 {
-  info "Help Me Obi-Wan Kenobi!"
-  if [ $check_bp_url == "true" ] ; then
+  if [ "$check_bp_url" = "true" ] ; then
     if [ -n "$opamp_endpoint" ]; then
-      HTTP_ENDPOINT="$(printf "${opamp_endpoint}" | sed 's#ws#http#' | sed 's#/v1/opamp$##')"
+      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed 's#ws#http#' | sed 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
-      if curl -s ${HTTP_ENDPOINT} > /dev/null; then
+      if curl -s "${HTTP_ENDPOINT}" > /dev/null; then
         succeeded
       else
         failed
-        warn "Connection to BindPlane has failed. Do you wish to continue installation?"
+        warn "Connection to BindPlane has failed."
         increase_indent
-        printf "${fg_yellow}Do you wish to continue installation?${reset}  "
+        printf "%sDo you wish to continue installation?%s  " "$fg_yellow" "$reset"
         prompt "n"
         decrease_indent
         read -n 1 -p "" input
@@ -512,8 +511,8 @@ install_package()
   # Move files to install dir
   for f in $FILES
   do
-    rm -rf "$INSTALL_DIR/$f"
-    cp "$TMP_DIR/artifacts/$f" "$INSTALL_DIR/$f" || error_exit "$LINENO" "Failed to copy artifact $f to install dir"
+    rm -rf "$INSTALL_DIR/${f:?}"
+    cp "$TMP_DIR/artifacts/${f:?}" "$INSTALL_DIR/${f:?}" || error_exit "$LINENO" "Failed to copy artifact $f to install dir"
   done
   decrease_indent
   succeeded

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -283,7 +283,7 @@ connection_check()
 {
   if [ "$check_bp_url" = "true" ] ; then
     if [ -n "$opamp_endpoint" ]; then
-      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed 's#ws#http#' | sed 's#/v1/opamp$##')"
+      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed 's#^ws#http#' | sed 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
       if curl -s "${HTTP_ENDPOINT}" > /dev/null; then

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -295,7 +295,7 @@ connection_check()
         printf "%sDo you wish to continue installation?%s  " "$fg_yellow" "$reset"
         prompt "n"
         decrease_indent
-        read -n 1 -p "" input
+        read -r input
         printf "\\n"
         if [ "$input" = "y" ] || [ "$input" = "Y" ]; then
           info "Continuing installation."

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -199,6 +199,11 @@ Usage:
     This parameter may also be provided through the SECRET_KEY environment variable.
     The '--endpoint' flag must be specified if this flag is specified.
 
+  $(fg_yellow '-c, --check-bp-url')
+    Check access to the BindPlane server URL.
+
+    This parameter will have the script check access to BindPlane based on the provided '--endpoint'
+
 EOF
   )
   info "$USAGE"
@@ -218,6 +223,7 @@ error_exit()
 {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
   error "ERROR ($SCRIPT_NAME$line_num): ${2:-Unknown Error}" >&2
+  shift 2
   if [ -n "$0" ]; then
     increase_indent
     error "$*"
@@ -270,6 +276,36 @@ check_prereqs()
   dependencies_check
   success "Prerequisite check complete!"
   decrease_indent
+}
+
+# Test connection to BindPlane if it was specified
+connection_check()
+{
+  info "Help Me Obi-Wan Kenobi!"
+  if [ $check_bp_url == "true" ] ; then
+    if [ -n "$opamp_endpoint" ]; then
+      HTTP_ENDPOINT="$(printf "${opamp_endpoint}" | sed 's#ws#http#' | sed 's#/v1/opamp$##')"
+      info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
+
+      if curl -s ${HTTP_ENDPOINT} > /dev/null; then
+        succeeded
+      else
+        failed
+        warn "Connection to BindPlane has failed. Do you wish to continue installation?"
+        increase_indent
+        printf "${fg_yellow}Do you wish to continue installation?${reset}  "
+        prompt "n"
+        decrease_indent
+        read -n 1 -p "" input
+        printf "\\n"
+        if [ "$input" = "y" ] || [ "$input" = "Y" ]; then
+          info "Continuing installation."
+        else
+          error_exit "$LINENO" "Aborting due to user input after connectivity failure between this system and the BindPlane server."
+        fi
+      fi
+    fi
+  fi
 }
 
 # This will check if the operating system is supported.
@@ -649,6 +685,8 @@ main()
           opamp_labels=$2 ; shift 2 ;;
         -s|--secret-key)
           opamp_secret_key=$2 ; shift 2 ;;
+        -c|--check-bp-url)
+          check_bp_url="true" ; shift 1 ;;
         -b|--base-url)
           base_url=$2 ; shift 2 ;;
       --)
@@ -662,6 +700,7 @@ main()
     done
   fi
 
+  connection_check
   setup_installation
   install_package
   display_results

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -474,7 +474,7 @@ connection_check()
         printf "%sDo you wish to continue installation?%s  " "$fg_yellow" "$reset"
         prompt "n"
         decrease_indent
-        read -n 1 -p "" input
+        read -r input
         printf "\\n"
         if [ "$input" = "y" ] || [ "$input" = "Y" ]; then
           info "Continuing installation."

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -462,7 +462,7 @@ connection_check()
 {
   if [ -n "$check_bp_url" ] ; then
     if [ -n "$opamp_endpoint" ]; then
-      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed -z 's#ws#http#' | sed -z 's#/v1/opamp$##')"
+      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed -z 's#^ws#http#' | sed -z 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
       if curl -s "${HTTP_ENDPOINT}" > /dev/null; then

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -465,7 +465,7 @@ connection_check()
       HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed -z 's#^ws#http#' | sed -z 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
-      if curl -s "${HTTP_ENDPOINT}" > /dev/null; then
+      if curl --max-time 20 -s "${HTTP_ENDPOINT}" > /dev/null; then
         succeeded
       else
         failed

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -75,7 +75,7 @@ printf() {
 }
 
 increase_indent() { indent="$INDENT_WIDTH$indent" ; }
-decrease_indent() { indent="${indent#*$INDENT_WIDTH}" ; }
+decrease_indent() { indent="${indent#*"$INDENT_WIDTH"}" ; }
 
 # Color functions reset only when given an argument
 bold() { command printf "$bold$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
@@ -462,16 +462,16 @@ connection_check()
 {
   if [ -n "$check_bp_url" ] ; then
     if [ -n "$opamp_endpoint" ]; then
-      HTTP_ENDPOINT="$(printf "${opamp_endpoint}" | sed -z 's#ws#http#' | sed -z 's#/v1/opamp$##')"
+      HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed -z 's#ws#http#' | sed -z 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
-      if curl -s ${HTTP_ENDPOINT} > /dev/null; then
+      if curl -s "${HTTP_ENDPOINT}" > /dev/null; then
         succeeded
       else
         failed
-        warn "Connection to BindPlane has failed. Do you wish to continue installation?"
+        warn "Connection to BindPlane has failed."
         increase_indent
-        printf "${fg_yellow}Do you wish to continue installation?${reset}  "
+        printf "%sDo you wish to continue installation?%s  " "$fg_yellow" "$reset"
         prompt "n"
         decrease_indent
         read -n 1 -p "" input


### PR DESCRIPTION
### Proposed Change
Add functionality to the install scripts to have it check the provided endpoint for connectivity prior to installation, and offer the user the ability to opt out.

This is feature gated by a command line flag (-c|--check-bp-url) to preserve backwards compatibility.

After this gets released, the BindPlane "Install Agent" should have the `-c` flag added

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
