### PR TITLE
fix(container-image): Upgrade base image to Ubuntu 23.10 to resolve tzdata install issues

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ FROM ubuntu:22.04
 WORKDIR /
 
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         --no-install-recommends \
         systemd tzdata ca-certificates && \
     apt-get clean && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -42,7 +42,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd \
-    --non-unique \
     --system \
     --no-create-home \
     --home /etc/otel \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -31,21 +31,21 @@ FROM eclipse-temurin:8-jdk as jdk
 
 # Final Stage
 #
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 WORKDIR /
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-get install -y \
         --no-install-recommends \
         systemd tzdata ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home /etc/otel \
+RUN useradd \
+    --non-unique \
+    --system \
     --no-create-home \
+    --home /etc/otel \
     --uid 10005 \
     --shell /sbin/nologin \
     otel


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

tzdata is prompting on install, which causes the build to fail. Setting `noninteractive` options did not help. Upgrading to 23.10 allows the package to install without prompting.

I had to replace `adduser` command with `useradd`. It is functionally the same.

tzdata error on 22.04

```
41.49 Errors were encountered while processing:
41.49  libc-bin
41.54 E: Sub-process /usr/bin/dpkg returned an error code (1)
------
Dockerfile:37
--------------------
  36 |     
  37 | >>> RUN apt-get update && \
  38 | >>>     DEBIAN_FRONTEND=noninteractive apt-get install -y \
  39 | >>>         --no-install-recommends \
  40 | >>>         systemd tzdata ca-certificates && \
  41 | >>>     apt-get clean && \
  42 | >>>     rm -rf /var/lib/apt/lists/*
  43 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get install -y         --no-install-recommends         systemd tzdata ca-certificates &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
