### PR TITLE
fix: Make install scripts uniform in behavior

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -266,6 +266,7 @@ check_prereqs()
 {
   banner "Checking Prerequisites"
   increase_indent
+  root_check
   os_check
   dependencies_check
   success "Prerequisite check complete!"
@@ -624,9 +625,7 @@ main()
   # (e.g. uninstall) can run
 
   observiq_banner
-
   check_prereqs
-  root_check  
 
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -730,6 +730,13 @@ uninstall()
 
 main()
 {
+  # We do these checks before we process arguments, because
+  # some of these options bail early, and we'd like to be sure that those commands
+  # (e.g. uninstall) can run
+
+  observiq_banner
+  check_prereqs
+
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do
       case "$1" in
@@ -772,8 +779,6 @@ main()
     done
   fi
 
-  observiq_banner
-  check_prereqs
   setup_installation
   install_package
   display_results


### PR DESCRIPTION
### Proposed Change
This brings both the OSX and UNIX install scripts into parity on behavior, as previously discussed with @BinaryFissionGames in another PR.

Edit:
Things not addressed by this PR:
Lack of support for all flags in the OSX script. Notably, proxy and local file install.

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
