### PR TITLE
chore: Removed deprecated memory ballast extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,7 +9,6 @@ Below is a list of supported extensions with links to their documentation pages.
 | Authenticator - OIDC Extension   | [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.91.0/extension/oidcauthextension/README.md) |
 | File Storage Extension           | [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.91.0/extension/storage/filestorage/README.md) |
 | Health Check Extension           | [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.91.0/extension/healthcheckextension/README.md) |
-| Memory Ballast Extension         | [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.91.0/extension/ballastextension/README.md) |
 | Performance Profiler Extension   | [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.91.0/extension/pprofextension/README.md) |
 | Sigv4 Authenticator Extension    | [sigv4authextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.91.0/extension/sigv4authextension/README.md) |
 | zPages Extension                 | [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.91.0/extension/zpagesextension/README.md) |

--- a/factories/extensions.go
+++ b/factories/extensions.go
@@ -23,13 +23,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 	"go.opentelemetry.io/collector/extension"
-	"go.opentelemetry.io/collector/extension/ballastextension"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	"go.opentelemetry.io/collector/extension/zpagesextension"
 )
 
 var defaultExtensions = []extension.Factory{
-	ballastextension.NewFactory(),
 	basicauthextension.NewFactory(),
 	bearertokenauthextension.NewFactory(),
 	extensiontest.NewNopFactory(),

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,6 @@ require (
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.91.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.91.0
 	go.opentelemetry.io/collector/extension v0.91.0
-	go.opentelemetry.io/collector/extension/ballastextension v0.91.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.91.0
 	go.opentelemetry.io/collector/featuregate v1.0.0
 	go.opentelemetry.io/collector/otelcol v0.91.0

--- a/go.sum
+++ b/go.sum
@@ -1809,8 +1809,6 @@ go.opentelemetry.io/collector/extension v0.91.0 h1:bkoSLgnWm4g6n+RLmyKG6Up7dr8Km
 go.opentelemetry.io/collector/extension v0.91.0/go.mod h1:F3r0fVTTh4sYR0GVv51Qez8lk8v77kTDPdyMOp6A2kg=
 go.opentelemetry.io/collector/extension/auth v0.91.0 h1:28Hv5W0GZgv2jR5IiFdJzutTs91KmXFh8DUfVTjwwmI=
 go.opentelemetry.io/collector/extension/auth v0.91.0/go.mod h1:diY6Sw7cOAn2qivKipZk4niBFzCCFBj7swAXiG2h9ro=
-go.opentelemetry.io/collector/extension/ballastextension v0.91.0 h1:/Ihh4FXFQH3LiDcQc28I5vqRzy8FMDMifRUQ4Tr15lc=
-go.opentelemetry.io/collector/extension/ballastextension v0.91.0/go.mod h1:D37HFnuhMtrCINliIoz2KzWid1wQQjEacT8CSIF3KwY=
 go.opentelemetry.io/collector/extension/zpagesextension v0.91.0 h1:d787uZ6cNHN1uaJ3pIgFlcrkHVB4ML6AlXBiCQRJ9t0=
 go.opentelemetry.io/collector/extension/zpagesextension v0.91.0/go.mod h1:S1T9YKuxRqCKFENC+GuEZhz0fzuUBACOrScNY13Y96w=
 go.opentelemetry.io/collector/featuregate v1.0.0 h1:5MGqe2v5zxaoo73BUOvUTunftX5J8RGrbFsC2Ha7N3g=


### PR DESCRIPTION
### Proposed Change
The [memory ballast](https://github.com/open-telemetry/opentelemetry-collector/tree/main/extension/ballastextension) extension has been deprecated in OTel in favor of using the `GOMEMLIMIT` environment variable. Removing it from the collector.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
