### PR TITLE
fix: Chronicle Transport Parameter in documentation

### DIFF
--- a/exporter/chronicleforwarderexporter/README.md
+++ b/exporter/chronicleforwarderexporter/README.md
@@ -22,7 +22,7 @@ The Chronicle Forwarder Exporter is designed for forwarding logs to a Chronicle 
 | export_type          | string | `syslog`          | `true`   | Type of export, either `syslog` or `file`.        |
 | raw_log_field        | string |                   | `false`  | The field name to send raw logs to Chronicle.     |
 | syslog.endpoint      | string | `127.0.0.1:10514` | `false`  | The Chronicle forwarder endpoint.                 |
-| syslog.network       | string | `tcp`             | `false`  | The network protocol to use (e.g., `tcp`, `udp`). |
+| syslog.transport     | string | `tcp`             | `false`  | The network protocol to use (e.g., `tcp`, `udp`). |
 | syslog.tls.key_file  | string |                   | `false`  | Configure the receiver to use TLS.                |
 | syslog.tls.cert_file | string |                   | `false`  | Configure the receiver to use TLS.                |
 | file.path            | string |                   | `false`  | The path to the file for storing logs.            |


### PR DESCRIPTION
### Proposed Change
<!-- Please provide a description of the change here. -->
- switch to `transport` instead of `network` parameter name in the documentation. 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
