### PR TITLE
fix(container): Java contrib JAR version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -256,6 +256,7 @@ dockers:
       - config/example.yaml
       - config/logging.stdout.yaml
       - LICENSE
+      - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
   - id: ubuntu-arm64
     goos: linux
     goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -301,6 +301,7 @@ dockers:
       - config/example.yaml
       - config/logging.stdout.yaml
       - LICENSE
+      - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
 
   - id: ubi8-amd64
     goos: linux
@@ -328,6 +329,7 @@ dockers:
       - config/example.yaml
       - config/logging.stdout.yaml
       - LICENSE
+      - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
   - id: ubi8-arm64
     goos: linux
     goarch: arm64
@@ -354,6 +356,7 @@ dockers:
       - config/example.yaml
       - config/logging.stdout.yaml
       - LICENSE
+      - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
 
 docker_manifests:
   - name_template: "observiq/observiq-otel-collector:latest"

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -55,7 +55,7 @@ RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
-COPY opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 
-# JMX stage downloads the opentelemetry-jmx-metrics.jar used by JMX receivers
-#
-FROM curlimages/curl:7.82.0 as jmxjar
-ARG JMX_JAR_VERSION=v1.15.0
-USER root
-RUN curl -L \
-    --output /opentelemetry-java-contrib-jmx-metrics.jar \
-    "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_JAR_VERSION}/opentelemetry-jmx-metrics.jar"
-
-
 # eclipse-temurn stage provides the Java runtime used by JMX receivers.
 # It is a replacement for the openjdk image, which is considered deprecated.
 #
@@ -65,7 +55,7 @@ RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
-COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 
-# JMX stage downloads the opentelemetry-jmx-metrics.jar used by JMX receivers
-#
-FROM curlimages/curl:7.82.0 as jmxjar
-ARG JMX_JAR_VERSION=v1.15.0
-USER root
-RUN curl -L \
-    --output /opentelemetry-java-contrib-jmx-metrics.jar \
-    "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_JAR_VERSION}/opentelemetry-jmx-metrics.jar"
-
-
 # eclipse-temurn stage provides the Java runtime used by JMX receivers.
 # It is a replacement for the openjdk image, which is considered deprecated.
 #
@@ -66,7 +56,7 @@ RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
-COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -56,7 +56,7 @@ RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
-COPY opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Instead of downloading the contrib jar using a multi-stage build, we should use the jar that was downloaded by the build script. This will prevent the container image jar version from becoming out of sync with JAVA_CONTRIB_VERSION (file in this repo).

After building with `make release-test`, Our security tool no longer identifies JAVA vulnerabilities. When I exec into the container and get the jar's checksum, it matches the checksum of the jar found in `release_deps/`.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
