### PR TITLE
fix: Disable otel for internal metrics

### DIFF
--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -31,6 +31,9 @@ func SetFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.mtimeSortType", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
 	}
+	if err := featuregate.GlobalRegistry().Set("telemetry.useOtelForInternalMetrics", false); err != nil {
+		return fmt.Errorf("failed to disable telemetry.useOtelForInternalMetrics: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Proposed Change
* Disable otel for internal metrics.

Right now, when we reconfigure with bindplane, it seems like old metric descriptors are not cleared when using the otel implementation for internal metrics. We need to go back to using the old OC implementation while we investigate how to get the new otel implementation working.

To test:
Create a config in bindplane with a destination using otlp (e.g. grafana)
Assign and rollout the config to the agent
Change a processor on the config and rollout the changes
run `curl localhost:8888/metrics`, observe that you don't get any errors (without this change, you will get errors about collecting multiple metrics with the same label set.)

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
