### PR TITLE
fix(snapshotsearch): Fix mintimestamp check for filtering

### DIFF
--- a/internal/report/snapshot/filter_logs.go
+++ b/internal/report/snapshot/filter_logs.go
@@ -105,7 +105,7 @@ func logMatches(l plog.LogRecord, queryMatchesResource bool, searchQuery *string
 
 // logMatchesTimestamp determines if the log came after the provided timestamp
 func logMatchesTimestamp(l plog.LogRecord, minimumTimestamp time.Time) bool {
-	return l.ObservedTimestamp() >= pcommon.NewTimestampFromTime(minimumTimestamp)
+	return l.ObservedTimestamp() > pcommon.NewTimestampFromTime(minimumTimestamp)
 }
 
 // logMatchesQuery determines if the given log record matches the given query string

--- a/internal/report/snapshot/filter_logs_test.go
+++ b/internal/report/snapshot/filter_logs_test.go
@@ -80,7 +80,7 @@ func TestFilterLogs(t *testing.T) {
 			name:             "Filters GET before timestamp",
 			fileIn:           filepath.Join(unfilteredLogsDir, "w3c-logs.yaml"),
 			query:            asPtr("GET"),
-			minimumTimestamp: asPtr(time.Unix(0, 1706632434906304000)),
+			minimumTimestamp: asPtr(time.Unix(0, 1706632434906303999)),
 			expectedFileOut:  filepath.Join(filteredLogsDir, "filters-get-timestamp.yaml"),
 		},
 	}

--- a/internal/report/snapshot/filter_metrics.go
+++ b/internal/report/snapshot/filter_metrics.go
@@ -222,7 +222,7 @@ func datapointMatches(dp datapoint, queryMatchesResource, queryMatchesName bool,
 }
 
 func datapointMatchesTimestamp(dp datapoint, minimumTimestamp time.Time) bool {
-	return dp.Timestamp() >= pcommon.NewTimestampFromTime(minimumTimestamp)
+	return dp.Timestamp() > pcommon.NewTimestampFromTime(minimumTimestamp)
 }
 
 func datapointMatchesQuery(dp datapoint, searchQuery string) bool {

--- a/internal/report/snapshot/filter_metrics_test.go
+++ b/internal/report/snapshot/filter_metrics_test.go
@@ -84,7 +84,7 @@ func TestFilterMetrics(t *testing.T) {
 			// note when regenning goldens. golden.WriteMetrics
 			// completely obliterates timestamps, so the regenerated golden will have the wrong timestamp.
 			// You'll have to manually fix that.
-			minimumTimestamp: asPtr(time.Unix(0, 3000000)),
+			minimumTimestamp: asPtr(time.Unix(0, 2999999)),
 			expectedFileOut:  filepath.Join(filteredMetricsDir, "filters-timestamp.yaml"),
 		},
 		{

--- a/internal/report/snapshot/filter_traces.go
+++ b/internal/report/snapshot/filter_traces.go
@@ -106,7 +106,7 @@ func spanMatches(s ptrace.Span, queryMatchesResource bool, searchQuery *string, 
 
 // spanMatchesTimestamp determines if the span came after the provided timestamp
 func spanMatchesTimestamp(s ptrace.Span, minTime time.Time) bool {
-	return s.EndTimestamp() >= pcommon.NewTimestampFromTime(minTime)
+	return s.EndTimestamp() > pcommon.NewTimestampFromTime(minTime)
 }
 
 // spanMatchesQuery determines if the given span matches the given query string


### PR DESCRIPTION
### Proposed Change
* The min timestamp check should be strictly greater than, not greater than or equal to

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
