### PR TITLE
fix(ci): Use larger runner for linux build, use macos-14

### DIFF
--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_darwin:
-    runs-on: macos-11
+    runs-on: macos-14
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022-8-cores]
+        os: [ubuntu-20.04, macos-14, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources


### PR DESCRIPTION
### Proposed Change
* The linux build step fails due to running out of disk space, so we need a larger runner
* macos-11 is now being deprecated, bump to [macos-14](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
