### PR TITLE
deps: Updated GitHub actions for node 20

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           check-latest: true
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           check-latest: true
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           check-latest: true
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           check-latest: true
@@ -103,7 +103,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21"
           check-latest: true
@@ -137,7 +137,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -61,7 +61,7 @@ jobs:
         run: go-msi.exe make -m observiq-otel-collector.msi --version ${{ github.event.inputs.version }} --arch amd64
         working-directory: C:/build
       - name: "Upload MSI"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: observiq-otel-collector.msi
           path: C:/build/observiq-otel-collector.msi
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -121,7 +121,7 @@ jobs:
         run: go-msi.exe make -m observiq-otel-collector-x86.msi --version ${{ github.event.inputs.version }} --arch 386
         working-directory: C:/build
       - name: "Upload MSI"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: observiq-otel-collector-x86.msi
           path: C:/build/observiq-otel-collector-x86.msi

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -59,7 +59,7 @@ jobs:
         run: go-msi.exe make -m observiq-otel-collector.msi --version ${{ github.ref_name }} --arch amd64
         working-directory: C:/build
       - name: "Upload MSI"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: observiq-otel-collector.msi
           path: C:/build/observiq-otel-collector.msi
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -120,7 +120,7 @@ jobs:
         run: go-msi.exe make -m observiq-otel-collector-x86.msi --version ${{ github.ref_name }} --arch 386
         working-directory: C:/build
       - name: "Upload MSI"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: observiq-otel-collector-x86.msi
           path: C:/build/observiq-otel-collector-x86.msi
@@ -137,7 +137,7 @@ jobs:
           # For goreleaser
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true
@@ -165,12 +165,12 @@ jobs:
           username: _json_key
           password: ${{ secrets.ORG_OBSERVIQ_PUBLIC_GCR_JSON_KEY }}
       - name: Retrieve Windows 64-bit MSI Installer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: observiq-otel-collector.msi
           path: observiq-otel-collector.msi
       - name: Retrieve Windows 32-bit MSI Installer
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: observiq-otel-collector-x86.msi
           path: observiq-otel-collector-x86.msi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           check-latest: true


### PR DESCRIPTION
### Proposed Change
Updated the following GitHub actions as they used node16 and need to support node 20
- actions/setup-go
- actions/download-artifact
- actions/upload-artifact

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
