### PR TITLE
feat(expr): use ottlfuncs.StandardConverters as base for ottl functions

### DIFF
--- a/expr/ottl.go
+++ b/expr/ottl.go
@@ -75,22 +75,14 @@ func NewOTTLLogRecordStatement(statementStr string, set component.TelemetrySetti
 // We include all the converter functions here (functions that do not edit telemetry),
 // as well as two custom functions, noop and value.
 func functions[T any]() map[string]ottl.Factory[T] {
-	return ottl.CreateFactoryMap[T](
-		ottlfuncs.NewConcatFactory[T](),
-		ottlfuncs.NewConvertCaseFactory[T](),
-		ottlfuncs.NewIntFactory[T](),
-		ottlfuncs.NewIsMatchFactory[T](),
-		ottlfuncs.NewLogFactory[T](),
-		ottlfuncs.NewParseJSONFactory[T](),
-		ottlfuncs.NewSpanIDFactory[T](),
-		ottlfuncs.NewSplitFactory[T](),
-		ottlfuncs.NewSubstringFactory[T](),
-		ottlfuncs.NewTraceIDFactory[T](),
-		ottlfuncs.NewUUIDFactory[T](),
+	noopFactory := newNoopFactory[T]()
+	valueFactory := newValueFactory[T]()
 
-		newNoopFactory[T](),
-		newValueFactory[T](),
-	)
+	factories := ottlfuncs.StandardConverters[T]()
+	factories[noopFactory.Name()] = noopFactory
+	factories[valueFactory.Name()] = valueFactory
+
+	return factories
 }
 
 // newNoopFactory returns a factory for the noop function, which does nothing.


### PR DESCRIPTION
### Proposed Change
* For OTTL, we should include the "StandardConverters" as our base for functions. 

I think this either originally didn't exist when we created the package, or I just missed it. Either way, we've slowly been drifting in terms of what functions are available in our processors vs what's available in docs and in the transform processor. 

This should help us keep up to date as functions are added to OTTL.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
