### PR TITLE
chore(snapshotsearch): Move filtered logs/traces instead of copying

### DIFF
--- a/internal/report/snapshot/filter_logs.go
+++ b/internal/report/snapshot/filter_logs.go
@@ -37,7 +37,7 @@ func filterLogs(logs plog.Logs, searchQuery *string, minimumTimestamp *time.Time
 
 		// Don't append empty resource logs
 		if filteredResourceLogs.ScopeLogs().Len() != 0 {
-			filteredResourceLogs.CopyTo(filteredLogs.ResourceLogs().AppendEmpty())
+			filteredResourceLogs.MoveTo(filteredLogs.ResourceLogs().AppendEmpty())
 		}
 	}
 
@@ -63,7 +63,7 @@ func filterResourceLogs(resourceLog plog.ResourceLogs, searchQuery *string, mini
 
 		// Don't append empty scope logs
 		if filteredScopeLogs.LogRecords().Len() != 0 {
-			filteredScopeLogs.CopyTo(filteredResourceLogs.ScopeLogs().AppendEmpty())
+			filteredScopeLogs.MoveTo(filteredResourceLogs.ScopeLogs().AppendEmpty())
 		}
 	}
 

--- a/internal/report/snapshot/filter_traces.go
+++ b/internal/report/snapshot/filter_traces.go
@@ -38,7 +38,7 @@ func filterTraces(traces ptrace.Traces, searchQuery *string, minimumTimestamp *t
 
 		// Don't append empty resource traces
 		if filteredResourceSpans.ScopeSpans().Len() != 0 {
-			filteredResourceSpans.CopyTo(filteredTraces.ResourceSpans().AppendEmpty())
+			filteredResourceSpans.MoveTo(filteredTraces.ResourceSpans().AppendEmpty())
 		}
 	}
 
@@ -64,7 +64,7 @@ func filterResourceSpans(resourceSpan ptrace.ResourceSpans, searchQuery *string,
 
 		// Don't append empty scope spans
 		if filteredScopeSpans.Spans().Len() != 0 {
-			filteredScopeSpans.CopyTo(filteredResourceSpans.ScopeSpans().AppendEmpty())
+			filteredScopeSpans.MoveTo(filteredResourceSpans.ScopeSpans().AppendEmpty())
 		}
 	}
 


### PR DESCRIPTION
### Proposed Change
The filtered log/trace objects are guaranteed to be copies of the original and are not used after they are aggregated, so we should be able to move them for a slight performance bump over copying them.

We already do this for metrics.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
