### PR TITLE
fix(httpreceiver): Check if server is nil before shutting it down

### DIFF
--- a/receiver/httpreceiver/logs.go
+++ b/receiver/httpreceiver/logs.go
@@ -100,6 +100,10 @@ func (r *httpLogsReceiver) Shutdown(ctx context.Context) error {
 // shutdownLIstener tells the server to stop serving and waits for it to stop
 func (r *httpLogsReceiver) shutdownListener(ctx context.Context) error {
 	r.logger.Debug("shutting down server")
+	if r.server == nil {
+		// Nothing to shut down
+		return nil
+	}
 
 	if err := r.server.Shutdown(ctx); err != nil {
 		return err

--- a/receiver/httpreceiver/logs_test.go
+++ b/receiver/httpreceiver/logs_test.go
@@ -16,6 +16,7 @@ package httpreceiver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -333,6 +334,17 @@ func TestServeHTTP(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShutdownNoServer(t *testing.T) {
+	// test that shutdown without a start does not error or panic
+	recv := newReceiver(t, &Config{
+		HTTPServerSettings: confighttp.HTTPServerSettings{
+			Endpoint: "localhost:12345",
+		},
+	}, consumertest.NewNop())
+
+	require.NoError(t, recv.Shutdown(context.Background()))
 }
 
 func newReceiver(t *testing.T, cfg *Config, c consumer.Logs) *httpLogsReceiver {


### PR DESCRIPTION
### Proposed Change
We've observed a nil panic when the http receiver is shutting down, due to server being nil:

```
Failed to apply config changes: failed to reload config: collector.yaml: collector failed to restart: collector panicked with error: runtime error: invalid memory address or nil pointer dereference. Panic stacktrace: goroutine 126 [running]: runtime/debug.Stack() /opt/hostedtoolcache/go/1.20.13/x64/src/runtime/debug/stack.go:24 +0x65 github.com/observiq/bindplane-agent/collector.(*collector).Run.func1.1() /home/runner/work/bindplane-agent/bindplane-agent/collector/collector.go:146 +0x66 panic({0x69484e0, 0xd6cb140}) /opt/hostedtoolcache/go/1.20.13/x64/src/runtime/panic.go:884 +0x213 net/http.(*Server).Shutdown(0x0, {0x87d1120, 0xc000b84c30}) /opt/hostedtoolcache/go/1.20.13/x64/src/net/http/server.go:2773 +0x5b github.com/observiq/bindplane-agent/receiver/httpreceiver.(*httpLogsReceiver).shutdownListener(0xc002cbe5a0, {0x87d1120, 0xc000b84c30}) /home/runner/work/bindplane-agent/bindplane-agent/receiver/httpreceiver/logs.go:104 +0x65 github.com/observiq/bindplane-agent/receiver/httpreceiver.(*httpLogsReceiver).Shutdown(0x3284000?, {0x87d1120?, 0xc000b84c30?}) /home/runner/work/bindplane-agent/bindplane-agent/receiver/httpreceiver/logs.go:97 +0x25 go.opentelemetry.io/collector/service/internal/graph.(*Graph).ShutdownAll(0xc00267a5a0, {0x87d1120, 0xc000b84c30}) /home/runner/go/pkg/mod/go.opentelemetry.io/collector/service@v0.92.0/internal/graph/graph.go:435 +0x1e8 go.opentelemetry.io/collector/service.(*Service).Shutdown(0xc002b9d4a0, {0x87d1120, 0xc000b84c30}) /home/runner/go/pkg/mod/go.opentelemetry.io/collector/service@v0.92.0/service.go:197 +0xda go.opentelemetry.io/collector/otelcol.(*Collector).setupConfigurationComponents(0xc000c66d20, {0x87d1120, 0xc000b84c30}) /home/runner/go/pkg/mod/go.opentelemetry.io/collector/otelcol@v0.92.0/collector.go:191 +0x785 go.opentelemetry.io/collector/otelcol.(*Collector).Run(0xc000c66d20, {0x87d1120, 0xc000b84c30}) /home/runner/go/pkg/mod/go.opentelemetry.io/collector/otelcol@v0.92.0/collector.go:229 +0x65 github.com/observiq/bindplane-agent/collector.(*collector).Run.func1() /home/runner/work/bindplane-agent/bindplane-agent/collector/collector.go:163 +0xdb created by github.com/observiq/bindplane-agent/collector.(*collector).Run /home/runner/work/bindplane-agent/bindplane-agent/collector/collector.go:136 +0x6ae 
```
This should protect against panicking if the server is not created (e.g. the toServer method fails, or if Shutdown is called without Start being called).

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
