### PR TITLE
chore: fix CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Install Go so we don't use an out of date version to auto-build
+      # https://github.com/github/codeql-action/issues/1842#issuecomment-1704398087
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
### Proposed Change
Codeql scanning is failing due to the go-version bump. 
Workaround from https://github.com/github/codeql-action/issues/1842 indicates we can install the go version we need before the init step to use the correct go version. 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
