### PR TITLE
fix: Panic in shutdown of multiple processors before start

### DIFF
--- a/processor/datapointcountprocessor/processor.go
+++ b/processor/datapointcountprocessor/processor.go
@@ -101,7 +101,9 @@ func (p *metricCountProcessor) Capabilities() consumer.Capabilities {
 
 // Shutdown stops the processor.
 func (p *metricCountProcessor) Shutdown(_ context.Context) error {
-	p.cancel()
+	if p.cancel != nil {
+		p.cancel()
+	}
 	p.wg.Wait()
 	return nil
 }

--- a/processor/datapointcountprocessor/processor_test.go
+++ b/processor/datapointcountprocessor/processor_test.go
@@ -37,6 +37,22 @@ func TestProcessorCapabilities(t *testing.T) {
 	require.Equal(t, consumer.Capabilities{MutatesData: false}, p.Capabilities())
 }
 
+func TestShutdownBeforeStart(t *testing.T) {
+	nextMetricConsumer := &consumertest.MetricsSink{}
+
+	processorCfg := createDefaultConfig().(*Config)
+	processorCfg.Interval = time.Millisecond * 100
+
+	processorFactory := NewFactory()
+	processorSettings := processor.CreateSettings{TelemetrySettings: component.TelemetrySettings{Logger: zaptest.NewLogger(t)}}
+	processor, err := processorFactory.CreateMetricsProcessor(context.Background(), processorSettings, processorCfg, nextMetricConsumer)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		processor.Shutdown(context.Background())
+	})
+}
+
 func TestConsumeMetrics(t *testing.T) {
 	countMetricConsumer := &consumertest.MetricsSink{}
 	nextMetricConsumer := &consumertest.MetricsSink{}

--- a/processor/logcountprocessor/processor.go
+++ b/processor/logcountprocessor/processor.go
@@ -96,7 +96,9 @@ func (p *logCountProcessor) Capabilities() consumer.Capabilities {
 
 // Shutdown stops the processor.
 func (p *logCountProcessor) Shutdown(_ context.Context) error {
-	p.cancel()
+	if p.cancel != nil {
+		p.cancel()
+	}
 	p.wg.Wait()
 	return nil
 }

--- a/processor/logcountprocessor/processor_test.go
+++ b/processor/logcountprocessor/processor_test.go
@@ -37,6 +37,22 @@ func TestProcessorCapabilities(t *testing.T) {
 	require.Equal(t, consumer.Capabilities{MutatesData: false}, p.Capabilities())
 }
 
+func TestShutdownBeforeStart(t *testing.T) {
+	logConsumer := &LogConsumer{logChan: make(chan plog.Logs, 1)}
+
+	processorCfg := createDefaultConfig().(*Config)
+	processorCfg.Interval = time.Millisecond * 100
+
+	processorFactory := NewFactory()
+	processorSettings := processor.CreateSettings{TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()}}
+	processor, err := processorFactory.CreateLogsProcessor(context.Background(), processorSettings, processorCfg, logConsumer)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		processor.Shutdown(context.Background())
+	})
+}
+
 func TestConsumeLogs(t *testing.T) {
 	logConsumer := &LogConsumer{logChan: make(chan plog.Logs, 1)}
 	metricConsumer := &MetricConsumer{metricChan: make(chan pmetric.Metrics, 1)}

--- a/processor/logdeduplicationprocessor/processor.go
+++ b/processor/logdeduplicationprocessor/processor.go
@@ -72,8 +72,9 @@ func (p *logDedupProcessor) Capabilities() consumer.Capabilities {
 
 // Shutdown stops the processor.
 func (p *logDedupProcessor) Shutdown(ctx context.Context) error {
-
-	p.cancel()
+	if p.cancel != nil {
+		p.cancel()
+	}
 
 	doneChan := make(chan struct{})
 	go func() {

--- a/processor/logdeduplicationprocessor/processor_test.go
+++ b/processor/logdeduplicationprocessor/processor_test.go
@@ -123,6 +123,26 @@ func TestProcessorCapabilities(t *testing.T) {
 	require.Equal(t, consumer.Capabilities{MutatesData: true}, p.Capabilities())
 }
 
+func TestShutdownBeforeStart(t *testing.T) {
+	logsSink := &consumertest.LogsSink{}
+	logger := zap.NewNop()
+	cfg := &Config{
+		LogCountAttribute: defaultLogCountAttribute,
+		Interval:          1 * time.Second,
+		Timezone:          defaultTimezone,
+		ExcludeFields: []string{
+			fmt.Sprintf("%s.remove_me", attributeField),
+		},
+	}
+
+	// Create a processor
+	p, err := newProcessor(cfg, logsSink, logger)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		p.Shutdown(context.Background())
+	})
+}
+
 func TestProcessorConsume(t *testing.T) {
 	logsSink := &consumertest.LogsSink{}
 	logger := zap.NewNop()

--- a/processor/lookupprocessor/processor.go
+++ b/processor/lookupprocessor/processor.go
@@ -61,7 +61,9 @@ func (p *lookupProcessor) start(_ context.Context, _ component.Host) error {
 
 // shutdown stops the processor
 func (p *lookupProcessor) shutdown(context.Context) error {
-	p.cancel()
+	if p.cancel != nil {
+		p.cancel()
+	}
 	p.wg.Wait()
 	return nil
 }

--- a/processor/lookupprocessor/processor_test.go
+++ b/processor/lookupprocessor/processor_test.go
@@ -15,9 +15,11 @@
 package lookupprocessor
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -407,6 +409,16 @@ func TestAddLookupValues(t *testing.T) {
 	}
 
 	require.Equal(t, expectedMap, sourceMap.AsRaw())
+}
+
+func TestShutdownBeforeStart(t *testing.T) {
+	processor := lookupProcessor{
+		wg:     &sync.WaitGroup{},
+		logger: zap.NewNop(),
+	}
+	require.NotPanics(t, func() {
+		processor.shutdown(context.Background())
+	})
 }
 
 // createTestCSVFile is a helper function to create a CSV file from a map

--- a/processor/spancountprocessor/processor.go
+++ b/processor/spancountprocessor/processor.go
@@ -97,7 +97,9 @@ func (p *spanCountProcessor) Capabilities() consumer.Capabilities {
 
 // Shutdown stops the processor.
 func (p *spanCountProcessor) Shutdown(_ context.Context) error {
-	p.cancel()
+	if p.cancel != nil {
+		p.cancel()
+	}
 	p.wg.Wait()
 	return nil
 }

--- a/processor/spancountprocessor/processor_test.go
+++ b/processor/spancountprocessor/processor_test.go
@@ -38,6 +38,21 @@ func TestProcessorCapabilities(t *testing.T) {
 	require.Equal(t, consumer.Capabilities{MutatesData: false}, p.Capabilities())
 }
 
+func TestShutdownBeforeStart(t *testing.T) {
+	nextTracesConsumer := &consumertest.TracesSink{}
+
+	processorCfg := createDefaultConfig().(*Config)
+	processorCfg.Interval = time.Millisecond * 100
+
+	processorFactory := NewFactory()
+	processorSettings := processor.CreateSettings{TelemetrySettings: component.TelemetrySettings{Logger: zaptest.NewLogger(t)}}
+	processor, err := processorFactory.CreateTracesProcessor(context.Background(), processorSettings, processorCfg, nextTracesConsumer)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		processor.Shutdown(context.Background())
+	})
+}
+
 func TestConsumeTraces(t *testing.T) {
 	countMetricConsumer := &consumertest.MetricsSink{}
 	nextTracesConsumer := &consumertest.TracesSink{}


### PR DESCRIPTION
### Proposed Change
Fixes possible panics in the following processors if they are shutdown before starting:
- logcount processor
- datapointcount processor
- logdeduplication processor
- lookup processor
- spancount processor

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
