### PR TITLE
fix(SLES15 systemd) Have the postinstall script remove the sysv init file if it exists on a systemd enabled system

### DIFF
--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -17,6 +17,11 @@
 set -e
 
 manage_systemd_service() {
+  # Ensure sysv script isn't present, and if it is remove it
+  if [ -f /etc/init.d/observiq-otel-collector ]; then
+    rm -f /etc/init.d/observiq-otel-collector
+  fi
+
   systemctl daemon-reload
 
   echo "configured systemd service"


### PR DESCRIPTION
### Proposed Change
Change the postinstall script to remove the sysv file on systems that don't need it.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
