### PR TITLE
chore: Update readme starting paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Action Test Status](https://github.com/observIQ/bindplane-agent/workflows/Tests/badge.svg)](https://github.com/observIQ/bindplane-agent/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/observIQ/bindplane-agent)](https://goreportcard.com/report/github.com/observIQ/bindplane-agent)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Gosec](https://github.com/observIQ/bindplane-agent/actions/workflows/gosec.yml/badge.svg)](https://github.com/observIQ/bindplane-agent/actions/workflows/gosec.yml)
 
 </center>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 </center>
 
-BindPlane Agent is observIQ’s distribution of the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector). It provides a simple and unified solution to collect, refine, and ship telemetry data anywhere.
+The BindPlane Agent is observIQ’s distribution of the [OpenTelemetry collector](https://github.com/open-telemetry/opentelemetry-collector). It’s the first distribution to implement the [Open Agent Management Protocol](https://opentelemetry.io/docs/specs/opamp/) (OpAMP) and is designed to be fully managed with [BindPlane OP](https://observiq.com/). To get started, follow our [Quickstart Guide](https://observiq.com/docs/getting-started/quickstart-guide).
 
 ## Benefits
 
@@ -63,11 +63,11 @@ For more installation information see [installing on macOS](/docs/installation-m
 
 Now that the agent is installed it is collecting basic metrics about the host machine printing them to the log. If you want to further configure your agent you may do so by editing the config file. To find your config file based on your OS reference the table below:
 
-| OS | Default Location |
-| :--- | :---- |
-| Linux | /opt/observiq-otel-collector/config.yaml |
+| OS      | Default Location                                              |
+|:--------|:--------------------------------------------------------------|
+| Linux   | /opt/observiq-otel-collector/config.yaml                      |
 | Windows | C:\Program Files\observIQ OpenTelemetry Collector\config.yaml |
-| macOS | /opt/observiq-otel-collector/config.yaml |
+| macOS   | /opt/observiq-otel-collector/config.yaml                      |
 
 For more information on configuration see the [Configuration section](#configuration).
 


### PR DESCRIPTION
### Proposed Change
Updates the first paragraph to nudge users towards BindPlane OP, the primary usage of the agent.

Also removed the gosec status badge, since the workflow no longer exists, and just leaves a dead link on the README.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
