### PR TITLE
fix(pluginreceiver): Add buffer to error channel in case shutdown causes error

### DIFF
--- a/receiver/pluginreceiver/factory.go
+++ b/receiver/pluginreceiver/factory.go
@@ -93,12 +93,5 @@ func createReceiver(cfg component.Config, set receiver.CreateSettings, emitterFa
 		return nil, fmt.Errorf("failed to render plugin: %w", err)
 	}
 
-	return &Receiver{
-		plugin:         plugin,
-		renderedCfg:    renderedCfg,
-		emitterFactory: emitterFactory,
-		logger:         set.Logger,
-		createService:  createService,
-		doneChan:       make(chan struct{}),
-	}, nil
+	return NewReceiver(plugin, renderedCfg, emitterFactory, set.Logger), nil
 }

--- a/receiver/pluginreceiver/receiver.go
+++ b/receiver/pluginreceiver/receiver.go
@@ -41,6 +41,7 @@ type Receiver struct {
 	serviceErrChan chan error
 }
 
+// NewReceiver creates a new plugin receiver
 func NewReceiver(
 	plugin *Plugin,
 	renderedConfig *RenderedConfig,

--- a/receiver/pluginreceiver/receiver.go
+++ b/receiver/pluginreceiver/receiver.go
@@ -35,7 +35,26 @@ type Receiver struct {
 	createService  createServiceFunc
 	service        Service
 
-	doneChan chan struct{}
+	// serviceErrChan gets the error from the service once it stops running.
+	// If there is no error, `nil` is placed on the channel.
+	// It will be closed after the collector service shuts down.
+	serviceErrChan chan error
+}
+
+func NewReceiver(
+	plugin *Plugin,
+	renderedConfig *RenderedConfig,
+	emitterFactory exporter.Factory,
+	logger *zap.Logger,
+) *Receiver {
+	return &Receiver{
+		plugin:         plugin,
+		renderedCfg:    renderedConfig,
+		emitterFactory: emitterFactory,
+		logger:         logger,
+		createService:  createService,
+		serviceErrChan: make(chan error, 1),
+	}
 }
 
 // Start starts the receiver's internal service
@@ -74,7 +93,10 @@ func (r *Receiver) Shutdown(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			r.logger.Warn("Context done before service properly shut down.", zap.Error(ctx.Err()))
-		case <-r.doneChan:
+		case err := <-r.serviceErrChan:
+			if err != nil {
+				return fmt.Errorf("shutdown service: %w", err)
+			}
 		}
 	}
 
@@ -83,12 +105,9 @@ func (r *Receiver) Shutdown(ctx context.Context) error {
 
 // startService starts the provided service
 func (r *Receiver) startService(ctx context.Context, svc Service) error {
-	errChan := make(chan error)
 	go func() {
-		if err := svc.Run(ctx); err != nil {
-			errChan <- err
-		}
-		close(r.doneChan)
+		r.serviceErrChan <- svc.Run(ctx)
+		close(r.serviceErrChan)
 	}()
 
 	ticker := time.NewTicker(time.Millisecond * 250)
@@ -98,7 +117,7 @@ func (r *Receiver) startService(ctx context.Context, svc Service) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case err := <-errChan:
+		case err := <-r.serviceErrChan:
 			return err
 		case <-ticker.C:
 			if svc.GetState() == otelcol.StateRunning {


### PR DESCRIPTION
### Proposed Change
* Fix potential lockup on shutdown of the plugin receiver, where it may attempt to emit an error on an unbuffered channel with no listener.
* Make a NewReceiver method that sets internal fields to the correct values (simplifies setup in tests a bit, especially with this channel that must be set up the same everywhere)


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
