### PR TITLE
feat(chronicle): Add support for setting log_type through an attribute

### DIFF
--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -48,7 +48,7 @@ currently supported log types are:
 - sql_server
 
 
-If the `attributes["chronicle_log_type"]` field is present in the log, we will use it's value in the payload instead of the automatic detection or the `log_type` in the config.
+If the `attributes["chronicle_log_type"]` field is present in the log, we will use its value in the payload instead of the automatic detection or the `log_type` in the config.
 
 ## Credentials
 

--- a/exporter/chronicleexporter/README.md
+++ b/exporter/chronicleexporter/README.md
@@ -47,6 +47,9 @@ currently supported log types are:
 - windows_event.system
 - sql_server
 
+
+If the `attributes["chronicle_log_type"]` field is present in the log, we will use it's value in the payload instead of the automatic detection or the `log_type` in the config.
+
 ## Credentials
 
 This exporter requires a Google Cloud service account with access to the Chronicle API. The service account must have access to the endpoint specfied in the config.

--- a/exporter/chronicleexporter/config.go
+++ b/exporter/chronicleexporter/config.go
@@ -17,6 +17,7 @@ package chronicleexporter
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/observiq/bindplane-agent/expr"
 	"go.opentelemetry.io/collector/component"
@@ -89,6 +90,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.Compression != gzip.Name && cfg.Compression != noCompression {
 		return fmt.Errorf("invalid compression type: %s", cfg.Compression)
+	}
+
+	if strings.HasPrefix(cfg.Endpoint, "http://") || strings.HasPrefix(cfg.Endpoint, "https://") {
+		return fmt.Errorf("endpoint should not contain a protocol: %s", cfg.Endpoint)
 	}
 
 	return nil

--- a/exporter/chronicleexporter/marshal_test.go
+++ b/exporter/chronicleexporter/marshal_test.go
@@ -146,7 +146,7 @@ func TestProtoMarshaler_MarshalRawLogs(t *testing.T) {
 			},
 			labels: []*api.Label{},
 			logRecords: func() plog.Logs {
-				return mockLogs(mockLogRecord("Log with overridden type", map[string]any{"log_type": "windows_event.custom"}))
+				return mockLogs(mockLogRecord("Log with overridden type", map[string]any{"log_type": "windows_event.application"}))
 			},
 			expectations: func(t *testing.T, requests []*api.BatchCreateLogsRequest) {
 				require.Len(t, requests, 1)
@@ -154,11 +154,28 @@ func TestProtoMarshaler_MarshalRawLogs(t *testing.T) {
 				require.Equal(t, "WINEVTLOG", batch.LogType, "Expected log type to be overridden by attribute")
 			},
 		},
+		{
+			name: "Override log type with chronicle attribute",
+			cfg: Config{
+				CustomerID:      uuid.New().String(),
+				LogType:         "DEFAULT", // This should be overridden by the chronicle_log_type attribute
+				RawLogField:     "body",
+				OverrideLogType: true,
+			},
+			labels: []*api.Label{},
+			logRecords: func() plog.Logs {
+				return mockLogs(mockLogRecord("Log with overridden type", map[string]any{"chronicle_log_type": "ASOC_ALERT"}))
+			},
+			expectations: func(t *testing.T, requests []*api.BatchCreateLogsRequest) {
+				require.Len(t, requests, 1)
+				batch := requests[0].Batch
+				require.Equal(t, "ASOC_ALERT", batch.LogType, "Expected log type to be overridden by attribute")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			marshaler, err := newProtoMarshaler(tt.cfg, component.TelemetrySettings{Logger: logger}, tt.labels)
 			marshaler.startTime = startTime
 			require.NoError(t, err)


### PR DESCRIPTION
### Proposed Change

- Add support for setting a log_type through an attribute rather than the config or automatic detection.
- Add additional validation to the config now that we're using the grpc protos.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
