### PR TITLE
chore: Don't skip internal modules when releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,6 @@ release:
 	@set -e; for dir in $(ALL_MODULES); do \
 	  if [ $${dir} == \. ]; then \
 	  	continue; \
-	  elif [[ $${dir} =~ ^\./internal ]]; then \
-	  	continue; \
 	  else \
 	    echo "$${dir}" | sed -e "s+^./++" -e 's+$$+/$(version)+' | awk '{print $1}' | git tag $$(cat)  ; \
 	  fi; \


### PR DESCRIPTION
### Proposed Change
* Don't skip internal modules when tagging for a release, we require these to be tagged to properly use the bindplane-agent module.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
