### PR TITLE
fix(googlecloudexporter): Skip setting host.name when k8s.pod.name is present

### DIFF
--- a/exporter/googlecloudexporter/exporter.go
+++ b/exporter/googlecloudexporter/exporter.go
@@ -175,37 +175,43 @@ func (e *googlecloudExporter) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// appendMetricHost appends hostname to metrics if not already present
+// appendMetricHost appends hostname to logs if host.name, host.id, or
+// k8s.pod.name not already present
 func (e *googlecloudExporter) appendMetricHost(md *pmetric.Metrics) {
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		resourceAttrs := md.ResourceMetrics().At(i).Resource().Attributes()
 		_, hostNameExists := resourceAttrs.Get(string(semconv.HostNameKey))
 		_, hostIDExists := resourceAttrs.Get(string(semconv.HostIDKey))
-		if !hostNameExists && !hostIDExists {
+		_, podNameExists := resourceAttrs.Get(string(semconv.K8SPodNameKey))
+		if !hostNameExists && !hostIDExists && !podNameExists {
 			resourceAttrs.PutStr(string(semconv.HostNameKey), hostname)
 		}
 	}
 }
 
-// appendLogHost appends hostname to logs if not already present
+// appendLogHost appends hostname to logs if host.name, host.id, or
+// k8s.pod.name not already present
 func (e *googlecloudExporter) appendLogHost(ld *plog.Logs) {
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		resourceAttrs := ld.ResourceLogs().At(i).Resource().Attributes()
 		_, hostNameExists := resourceAttrs.Get(string(semconv.HostNameKey))
 		_, hostIDExists := resourceAttrs.Get(string(semconv.HostIDKey))
-		if !hostNameExists && !hostIDExists {
+		_, podNameExists := resourceAttrs.Get(string(semconv.K8SPodNameKey))
+		if !hostNameExists && !hostIDExists && !podNameExists {
 			resourceAttrs.PutStr(string(semconv.HostNameKey), hostname)
 		}
 	}
 }
 
-// appendTraceHost appends hostname to traces if not already present
+// appendTraceHost appends hostname to logs if host.name, host.id, or
+// k8s.pod.name not already present
 func (e *googlecloudExporter) appendTraceHost(td *ptrace.Traces) {
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceAttrs := td.ResourceSpans().At(i).Resource().Attributes()
 		_, hostNameExists := resourceAttrs.Get(string(semconv.HostNameKey))
 		_, hostIDExists := resourceAttrs.Get(string(semconv.HostIDKey))
-		if !hostNameExists && !hostIDExists {
+		_, podNameExists := resourceAttrs.Get(string(semconv.K8SPodNameKey))
+		if !hostNameExists && !hostIDExists && !podNameExists {
 			resourceAttrs.PutStr(string(semconv.HostNameKey), hostname)
 		}
 	}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The exporter sets host.name in an effort to ensure telemetry is identifiable. The presence of host.name allows the telemetry to map to `generic_node` [Monitored Resource Type](https://cloud.google.com/monitoring/api/resources#tag_generic_node).

Because k8s.pod.name is an identifiable attribute similar to host.name, we can skip setting host.name when it is present. This might help prevent metrics from mapping to generic_node when they should really be k8s_container or k8s_pod monitored resource types.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
