### PR TITLE
chore: release test ease of use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ release-prep:
 # Build and sign, skip release and ignore dirty git tree
 .PHONY: release-test
 release-test:
-	GORELEASER_CURRENT_TAG=$(shell git tag | grep -E -i '^v[0-9]+\.[0-9]+\.[0-9]+' | sort -r --version-sort | head -n1) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
+	if [ ! -e "./observiq-otel-collector.msi" ]; then touch ./observiq-otel-collector.msi; fi
+	GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
 
 .PHONY: for-all
 for-all:

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ release-prep:
 # Build and sign, skip release and ignore dirty git tree
 .PHONY: release-test
 release-test:
+# If there is no MSI in the root dir, we'll create a dummy one so that goreleaser can complete successfully
 	if [ ! -e "./observiq-otel-collector.msi" ]; then touch ./observiq-otel-collector.msi; fi
 	GORELEASER_CURRENT_TAG=$(VERSION) goreleaser release --parallelism 4 --skip=publish --skip=validate --skip=sign --clean --snapshot
 


### PR DESCRIPTION
### Proposed Change
* Use `VERSION` make file var for GORELEASER_CURRENT_TAG in release-test
  * This lets you set the version of the build by doing `VERSION=v1.xx.x make release-test`
* Create a dummy windows MSI if one isn't present
  * This is required for checksums, but usually it's not worth going through the effort of actually getting one of these built. So a dummy one will be created if one doesn't exist

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
