### PR TITLE
feat: Update Unix install script

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -238,6 +238,7 @@ dockers:
     goarch: amd64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
       - "ghcr.io/observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
@@ -260,6 +261,7 @@ dockers:
     goarch: arm64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
       - "ghcr.io/observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
@@ -282,6 +284,7 @@ dockers:
     goarch: amd64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/observiq-otel-collector-amd64:latest"
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
@@ -327,6 +330,7 @@ dockers:
     goarch: arm64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/observiq-otel-collector-arm64:latest"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
@@ -373,6 +377,7 @@ dockers:
     goarch: amd64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
@@ -400,6 +405,7 @@ dockers:
     goarch: arm64
     ids:
       - collector
+      - supervisor
     image_templates:
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,6 +156,7 @@ nfpms:
           mode: 0755
           owner: observiq-otel-collector
           group: observiq-otel-collector
+      # TODO: (dakota) evaluate this file once supervisor has support for configuring agent logging
       - src: release_deps/logging.yaml
         dst: /opt/observiq-otel-collector/logging.yaml
         file_info:
@@ -200,6 +201,16 @@ nfpms:
           mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
+      - dst: /opt/observiq-otel-collector/supervisor_storage
+        type: dir
+        file_info:
+          mode: 0750
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+      - dst: /opt/observiq-otel-collector/supervisor_storage/effective.yaml
+        type: ghost
+      - dst: /opt/observiq-otel-collector/supervisor_storage/agent.log
+        type: ghost
       - src: service/observiq-otel-collector.service
         dst: /usr/lib/systemd/system/observiq-otel-collector.service
         type: config|noreplace

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -230,6 +230,8 @@ nfpms:
     scripts:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh
+      preremove: ./scripts/package/preremove.sh
+      postremove: ./scripts/package/postremove.sh
 
 # Build container images with docker buildx (mutli arch builds).
 dockers:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -200,12 +200,6 @@ nfpms:
           mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
-      - dst: /opt/observiq-otel-collector/log
-        type: dir
-        file_info:
-          mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
       - src: service/observiq-otel-collector.service
         dst: /usr/lib/systemd/system/observiq-otel-collector.service
         type: config|noreplace

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ updater:
 # Runs the supervisor invoking the agent build in /dist
 .PHONY: run-supervisor
 run-supervisor:
-	opampsupervisor --config ./local/supervisor-config.yaml
+	opampsupervisor --config ./local/supervisor.yaml
 
 # Ensures the supervisor and agent are stopped
 .PHONY: kill

--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -35,7 +35,7 @@ SUPERVISOR_REPO="https://github.com/open-telemetry/opentelemetry-collector-contr
 PLATFORMS=("linux/amd64" "linux/arm64" "linux/arm" "linux/ppc64" "linux/ppc64le" "darwin/amd64" "darwin/arm64" "windows/amd64")
 
 mkdir "$DOWNLOAD_DIR/supervisor_bin"
-$(cd $DOWNLOAD_DIR && git clone "$SUPERVISOR_REPO")
+$(cd $DOWNLOAD_DIR && git clone --depth 1 "$SUPERVISOR_REPO")
 cd "$DOWNLOAD_DIR/opentelemetry-collector-contrib/cmd/opampsupervisor"
 go get github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor
 for PLATFORM in "${PLATFORMS[@]}"; do

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -37,10 +37,11 @@ COPY --from=stage --chown=otel:otel /etc/otel /etc/otel
 COPY --from=stage --chown=otel:otel /etc/otel/storage /etc/otel/storage
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
+COPY opampsupervisor /collector/opampsupervisor
 
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel
-ENTRYPOINT ["/collector/observiq-otel-collector"]
+ENTRYPOINT ["/collector/opampsupervisor"]

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -44,4 +44,4 @@ ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel
-ENTRYPOINT ["/collector/opampsupervisor"]
+ENTRYPOINT [ "/collector/opampsupervisor" ]

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -44,4 +44,4 @@ ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel
-ENTRYPOINT [ "/collector/opampsupervisor" ]
+ENTRYPOINT [ "/collector/opampsupervisor", "--config", "/etc/otel/supervisor.yaml" ]

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -57,6 +57,8 @@ COPY LICENSE /licenses/observiq-otel-collector.license
 COPY release_deps/VERSION.txt /etc/otel/VERSION.txt
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
+COPY opampsupervisor /collector/opampsupervisor
+
 COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY release_deps/plugins /etc/otel/plugins
 
@@ -73,4 +75,4 @@ WORKDIR /etc/otel
 
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
 # connecting to an OpAMP platform.
-ENTRYPOINT [ "/collector/observiq-otel-collector" ]
+ENTRYPOINT [ "/collector/opampsupervisor" ]

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -73,6 +73,4 @@ RUN chmod 0600 \
 USER otel
 WORKDIR /etc/otel
 
-# User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
-# connecting to an OpAMP platform.
 ENTRYPOINT [ "/collector/opampsupervisor" ]

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -73,4 +73,4 @@ RUN chmod 0600 \
 USER otel
 WORKDIR /etc/otel
 
-ENTRYPOINT [ "/collector/opampsupervisor" ]
+ENTRYPOINT [ "/collector/opampsupervisor", "--config", "/etc/otel/supervisor.yaml" ]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -74,6 +74,4 @@ RUN chmod 0600 \
 USER otel
 WORKDIR /etc/otel
 
-# User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
-# connecting to an OpAMP platform.
 ENTRYPOINT [ "/collector/opampsupervisor" ]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -74,4 +74,4 @@ RUN chmod 0600 \
 USER otel
 WORKDIR /etc/otel
 
-ENTRYPOINT [ "/collector/opampsupervisor" ]
+ENTRYPOINT [ "/collector/opampsupervisor", "--config", "/etc/otel/supervisor.yaml" ]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -58,6 +58,8 @@ COPY LICENSE /licenses/observiq-otel-collector.license
 COPY release_deps/VERSION.txt /etc/otel/VERSION.txt
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
+COPY opampsupervisor /collector/opampsupervisor
+
 COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY release_deps/plugins /etc/otel/plugins
 
@@ -74,4 +76,4 @@ WORKDIR /etc/otel
 
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
 # connecting to an OpAMP platform.
-ENTRYPOINT [ "/collector/observiq-otel-collector" ]
+ENTRYPOINT [ "/collector/opampsupervisor" ]

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -103,4 +103,4 @@ require (
 )
 
 // Needed until 'version' package changes are included in a release
-replace github.com/observiq/bindplane-agent/internal/version v1.56.0 => github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab
+replace github.com/observiq/bindplane-agent/internal/version => ../../internal/version

--- a/exporter/googlecloudexporter/go.sum
+++ b/exporter/googlecloudexporter/go.sum
@@ -249,8 +249,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
-github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab h1:sj9huSMQ9MqOWRGJ1OJtIhpXZZpg1OoB8YvJ3kBCYlg=
-github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab/go.mod h1:TfycUeyrZvoFI6crSlts5HxdHgxYtoYaXwSZ2ZQIj5I=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.104.0 h1:fDH7tK/opMyqQmDhpmZULIrNGngoskt9XOQMEpFFF5g=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.104.0/go.mod h1:fmfg4BgrR8xPS10kTUSM55PFmGgAoTVOEXHf41dEBTw=

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -103,4 +103,4 @@ require (
 )
 
 // Needed until 'version' package changes are included in a release
-replace github.com/observiq/bindplane-agent/internal/version v1.56.0 => github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab
+replace github.com/observiq/bindplane-agent/internal/version => ../../internal/version

--- a/exporter/googlemanagedprometheusexporter/go.sum
+++ b/exporter/googlemanagedprometheusexporter/go.sum
@@ -260,8 +260,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
-github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab h1:sj9huSMQ9MqOWRGJ1OJtIhpXZZpg1OoB8YvJ3kBCYlg=
-github.com/observiq/bindplane-agent/internal/version v0.0.0-20240717172323-a1d3e6ed4aab/go.mod h1:TfycUeyrZvoFI6crSlts5HxdHgxYtoYaXwSZ2ZQIj5I=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.105.0 h1:OA2vHArCVEJfEXl5tFGVTg1P0Dy0EQ33mVRLs4Ofcp0=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.105.0/go.mod h1:Tm2Xa5r29dC5xzflcnOg8EuruPcgD7kNX61mvQSSEjc=

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -23,7 +23,7 @@ DOWNLOAD_BASE="https://github.com/observIQ/bindplane-agent/releases/download"
 PREREQS="printf sed uname tr find grep"
 TMP_DIR="${TMPDIR:-"/tmp/"}observiq-otel-collector" # Allow this to be overriden by cannonical TMPDIR env var
 INSTALL_DIR="/opt/observiq-otel-collector"
-SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor-config.yaml"
+SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor.yaml"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
@@ -517,7 +517,7 @@ install_package() {
     succeeded
   fi
 
-  # If an endpoint was specified, we need to write the supervisor-config.yaml
+  # If an endpoint was specified, we need to write the supervisor.yaml
   if [ -n "$OPAMP_ENDPOINT" ]; then
     create_supervisor_config "$SUPERVISOR_YML_PATH"
   fi

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -20,9 +20,9 @@ PACKAGE_NAME="observiq-otel-collector"
 DOWNLOAD_BASE="https://github.com/observIQ/bindplane-agent/releases/download"
 
 # Determine if we need service or systemctl for prereqs
-if command -v systemctl > /dev/null 2>&1; then
+if command -v systemctl >/dev/null 2>&1; then
   SVC_PRE=systemctl
-elif command -v service > /dev/null 2>&1; then
+elif command -v service >/dev/null 2>&1; then
   SVC_PRE=service
 fi
 
@@ -74,7 +74,7 @@ fi
 # Helper Functions
 printf() {
   if command -v sed >/dev/null; then
-    command printf -- "$@" | sed -r "$sed_ignore s/^/$indent/g"  # Ignore sole reset characters if defined
+    command printf -- "$@" | sed -r "$sed_ignore s/^/$indent/g" # Ignore sole reset characters if defined
   else
     # Ignore $* suggestion as this breaks the output
     # shellcheck disable=SC2145
@@ -82,36 +82,36 @@ printf() {
   fi
 }
 
-increase_indent() { indent="$INDENT_WIDTH$indent" ; }
-decrease_indent() { indent="${indent#*"$INDENT_WIDTH"}" ; }
+increase_indent() { indent="$INDENT_WIDTH$indent"; }
+decrease_indent() { indent="${indent#*"$INDENT_WIDTH"}"; }
 
 # Color functions reset only when given an argument
-bold() { command printf "$bold$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-underline() { command printf "$underline$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-standout() { command printf "$standout$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
+bold() { command printf "$bold$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+underline() { command printf "$underline$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+standout() { command printf "$standout$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
 # Ignore "parameters are never passed"
 # shellcheck disable=SC2120
-reset() { command printf "$reset$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_black() { command printf "$bg_black$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_blue() { command printf "$bg_blue$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_cyan() { command printf "$bg_cyan$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_green() { command printf "$bg_green$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_magenta() { command printf "$bg_magenta$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_red() { command printf "$bg_red$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_white() { command printf "$bg_white$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-bg_yellow() { command printf "$bg_yellow$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_black() { command printf "$fg_black$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_blue() { command printf "$fg_blue$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_cyan() { command printf "$fg_cyan$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_green() { command printf "$fg_green$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_magenta() { command printf "$fg_magenta$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_red() { command printf "$fg_red$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_white() { command printf "$fg_white$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
-fg_yellow() { command printf "$fg_yellow$*$(if [ -n "$1" ]; then command printf "$reset"; fi)" ; }
+reset() { command printf "$reset$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_black() { command printf "$bg_black$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_blue() { command printf "$bg_blue$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_cyan() { command printf "$bg_cyan$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_green() { command printf "$bg_green$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_magenta() { command printf "$bg_magenta$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_red() { command printf "$bg_red$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_white() { command printf "$bg_white$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+bg_yellow() { command printf "$bg_yellow$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_black() { command printf "$fg_black$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_blue() { command printf "$fg_blue$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_cyan() { command printf "$fg_cyan$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_green() { command printf "$fg_green$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_magenta() { command printf "$fg_magenta$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_red() { command printf "$fg_red$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_white() { command printf "$fg_white$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
+fg_yellow() { command printf "$fg_yellow$*$(if [ -n "$1" ]; then command printf "$reset"; fi)"; }
 
 # Intentionally using variables in format string
 # shellcheck disable=SC2059
-info() { printf "$*\\n" ; }
+info() { printf "$*\\n"; }
 # Intentionally using variables in format string
 # shellcheck disable=SC2059
 warn() {
@@ -128,7 +128,7 @@ error() {
 }
 # Intentionally using variables in format string
 # shellcheck disable=SC2059
-success() { printf "$fg_green$*$reset\\n" ; }
+success() { printf "$fg_green$*$reset\\n"; }
 # Ignore 'arguments are never passed'
 # shellcheck disable=SC2120
 prompt() {
@@ -139,8 +139,7 @@ prompt() {
   fi
 }
 
-observiq_banner()
-{
+observiq_banner() {
   fg_cyan "           888                                        8888888 .d88888b.\\n"
   fg_cyan "           888                                          888  d88P\" \"Y88b\\n"
   fg_cyan "           888                                          888  888     888\\n"
@@ -154,20 +153,19 @@ observiq_banner()
   reset
 }
 
-separator() { printf "===================================================\\n" ; }
+separator() { printf "===================================================\\n"; }
 
-banner()
-{
+banner() {
   printf "\\n"
   separator
-  printf "| %s\\n" "$*" ;
+  printf "| %s\\n" "$*"
   separator
 }
 
-usage()
-{
+usage() {
   increase_indent
-  USAGE=$(cat <<EOF
+  USAGE=$(
+    cat <<EOF
 Usage:
   $(fg_yellow '-v, --version')
       Defines the version of the BindPlane Agent.
@@ -231,16 +229,14 @@ EOF
   return 0
 }
 
-force_exit()
-{
+force_exit() {
   # Exit regardless of subshell level with no "Terminated" message
   kill -PIPE $$
   # Call exit to handle special circumstances (like running script during docker container build)
   exit 1
 }
 
-error_exit()
-{
+error_exit() {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
   error "ERROR ($SCRIPT_NAME$line_num): ${2:-Unknown Error}" >&2
   if [ -n "$0" ]; then
@@ -251,16 +247,14 @@ error_exit()
   force_exit
 }
 
-print_prereq_line()
-{
+print_prereq_line() {
   if [ -n "$2" ]; then
     command printf "\\n${indent}  - "
     command printf "[$1]: $2"
   fi
 }
 
-check_failure()
-{
+check_failure() {
   if [ "$indent" != '' ]; then increase_indent; fi
   command printf "${indent}${fg_red}ERROR: %s check failed!${reset}" "$1"
 
@@ -274,61 +268,57 @@ check_failure()
   force_exit
 }
 
-succeeded()
-{
+succeeded() {
   increase_indent
   success "Succeeded!"
   decrease_indent
 }
 
-failed()
-{
+failed() {
   error "Failed!"
 }
 
 # This will set all installation variables
 # at the beginning of the script.
-setup_installation()
-{
-    banner "Configuring Installation Variables"
-    increase_indent
+setup_installation() {
+  banner "Configuring Installation Variables"
+  increase_indent
 
-    # Installation variables
-    set_os_arch
-    set_package_type
+  # Installation variables
+  set_os_arch
+  set_package_type
 
-    # if package_path is not set then download the package
-    if [ -z "$package_path" ]; then
-      set_download_urls
-      set_proxy
-      set_file_name
-    else
-      out_file_path="$package_path"
-    fi
+  # if package_path is not set then download the package
+  if [ -z "$package_path" ]; then
+    set_download_urls
+    set_proxy
+    set_file_name
+  else
+    out_file_path="$package_path"
+  fi
 
-    set_opamp_endpoint
-    set_opamp_labels
-    set_opamp_secret_key
+  set_opamp_endpoint
+  set_opamp_labels
+  set_opamp_secret_key
 
-    success "Configuration complete!"
-    decrease_indent
+  success "Configuration complete!"
+  decrease_indent
 }
 
 set_file_name() {
-  if [ -z "$version" ] ; then
+  if [ -z "$version" ]; then
     package_file_name="${PACKAGE_NAME}_linux_${arch}.${package_type}"
   else
     package_file_name="${PACKAGE_NAME}_v${version}_linux_${arch}.${package_type}"
   fi
-    out_file_path="$TMP_DIR/$package_file_name"
+  out_file_path="$TMP_DIR/$package_file_name"
 }
 
-set_proxy()
-{
+set_proxy() {
   if [ -n "$proxy" ]; then
     info "Using proxy from arguments: $proxy"
     if [ -n "$proxy_user" ]; then
-      while [ -z "$proxy_password" ] ; do
+      while [ -z "$proxy_password" ]; do
         increase_indent
         command printf "${indent}$(fg_blue "$proxy_user@$proxy")'s password: "
         stty -echo
@@ -351,58 +341,55 @@ set_proxy()
   fi
 }
 
-
-set_os_arch()
-{
+set_os_arch() {
   os_arch=$(uname -m)
-  case "$os_arch" in 
-    # arm64 strings. These are from https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
-    aarch64|arm64|aarch64_be|armv8b|armv8l)
-      os_arch="arm64"
-      ;;
-    x86_64)
-      os_arch="amd64"
-      ;;
-    # experimental PowerPC arch support for collector
-    ppc64)
-      os_arch="ppc64"
-      ;;
-    ppc64le)
-      os_arch="ppc64le"
-      ;;
-    # armv6/32bit. These are what raspberry pi can return, which is the main reason we support 32-bit arm
-    arm|armv6l|armv7l)
-      os_arch="arm"
-      ;;
-    *)
-      error_exit "$LINENO" "Unsupported os arch: $os_arch"
-      ;;
+  case "$os_arch" in
+  # arm64 strings. These are from https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
+  aarch64 | arm64 | aarch64_be | armv8b | armv8l)
+    os_arch="arm64"
+    ;;
+  x86_64)
+    os_arch="amd64"
+    ;;
+  # experimental PowerPC arch support for collector
+  ppc64)
+    os_arch="ppc64"
+    ;;
+  ppc64le)
+    os_arch="ppc64le"
+    ;;
+  # armv6/32bit. These are what raspberry pi can return, which is the main reason we support 32-bit arm
+  arm | armv6l | armv7l)
+    os_arch="arm"
+    ;;
+  *)
+    error_exit "$LINENO" "Unsupported os arch: $os_arch"
+    ;;
   esac
 }
 
 # Set the package type before install
-set_package_type()
-{
+set_package_type() {
   # if package_path is set get the file extension otherwise look at what's available on the system
   if [ -n "$package_path" ]; then
     case "$package_path" in
-      *.deb)
-        package_type="deb"
-        ;;
-      *.rpm)
-        package_type="rpm"
-        ;;
-      *)
-        error_exit "$LINENO" "Unsupported package type: $package_path"
-        ;;
+    *.deb)
+      package_type="deb"
+      ;;
+    *.rpm)
+      package_type="rpm"
+      ;;
+    *)
+      error_exit "$LINENO" "Unsupported package type: $package_path"
+      ;;
     esac
   else
-    if command -v dpkg > /dev/null 2>&1; then
-        package_type="deb"
-    elif command -v rpm > /dev/null 2>&1; then
-        package_type="rpm"
+    if command -v dpkg >/dev/null 2>&1; then
+      package_type="deb"
+    elif command -v rpm >/dev/null 2>&1; then
+      package_type="rpm"
     else
-        error_exit "$LINENO" "Could not find dpkg or rpm on the system"
+      error_exit "$LINENO" "Could not find dpkg or rpm on the system"
     fi
   fi
 
@@ -411,23 +398,22 @@ set_package_type()
 # This will set the urls to use when downloading the agent and its plugins.
 # These urls are constructed based on the --version flag or COLLECTOR_VERSION env variable.
 # If not specified, the version defaults to whatever the latest release on github is.
-set_download_urls()
-{
-  if [ -z "$url" ] ; then
-    if [ -z "$version" ] ; then
+set_download_urls() {
+  if [ -z "$url" ]; then
+    if [ -z "$version" ]; then
       # shellcheck disable=SC2153
       version=$COLLECTOR_VERSION
     fi
 
-    if [ -z "$version" ] ; then
+    if [ -z "$version" ]; then
       version=$(latest_version)
     fi
 
-    if [ -z "$version" ] ; then
+    if [ -z "$version" ]; then
       error_exit "$LINENO" "Could not determine version to install"
     fi
 
-    if [ -z "$base_url" ] ; then
+    if [ -z "$base_url" ]; then
       base_url=$DOWNLOAD_BASE
     fi
 
@@ -437,18 +423,16 @@ set_download_urls()
   fi
 }
 
-set_opamp_endpoint()
-{
-  if [ -z "$opamp_endpoint" ] ; then
+set_opamp_endpoint() {
+  if [ -z "$opamp_endpoint" ]; then
     opamp_endpoint="$ENDPOINT"
   fi
 
   OPAMP_ENDPOINT="$opamp_endpoint"
 }
 
-set_opamp_labels()
-{
-  if [ -z "$opamp_labels" ] ; then
+set_opamp_labels() {
+  if [ -z "$opamp_labels" ]; then
     opamp_labels=$LABELS
   fi
 
@@ -459,9 +443,8 @@ set_opamp_labels()
   fi
 }
 
-set_opamp_secret_key()
-{
-  if [ -z "$opamp_secret_key" ] ; then
+set_opamp_secret_key() {
+  if [ -z "$opamp_secret_key" ]; then
     opamp_secret_key=$SECRET_KEY
   fi
 
@@ -473,14 +456,13 @@ set_opamp_secret_key()
 }
 
 # Test connection to BindPlane if it was specified
-connection_check()
-{
-  if [ -n "$check_bp_url" ] ; then
+connection_check() {
+  if [ -n "$check_bp_url" ]; then
     if [ -n "$opamp_endpoint" ]; then
       HTTP_ENDPOINT="$(echo "${opamp_endpoint}" | sed -z 's#^ws#http#' | sed -z 's#/v1/opamp$##')"
       info "Testing connection to BindPlane: $fg_magenta$HTTP_ENDPOINT$reset..."
 
-      if curl --max-time 20 -s "${HTTP_ENDPOINT}" > /dev/null; then
+      if curl --max-time 20 -s "${HTTP_ENDPOINT}" >/dev/null; then
         succeeded
       else
         failed
@@ -502,8 +484,7 @@ connection_check()
 }
 
 # This will check all prerequisites before running an installation.
-check_prereqs()
-{
+check_prereqs() {
   banner "Checking Prerequisites"
   increase_indent
   root_check
@@ -516,52 +497,47 @@ check_prereqs()
 }
 
 # This checks to see if the user who is running the script has root permissions.
-root_check()
-{
+root_check() {
   system_user_name=$(id -un)
-  if [ "${system_user_name}" != 'root' ]
-  then
+  if [ "${system_user_name}" != 'root' ]; then
     failed
     error_exit "$LINENO" "Script needs to be run as root or with sudo"
   fi
 }
 
 # This will check if the operating system is supported.
-os_check()
-{
+os_check() {
   info "Checking that the operating system is supported..."
   os_type=$(uname -s)
   case "$os_type" in
-    Linux)
-      succeeded
-      ;;
-    *)
-      failed
-      error_exit "$LINENO" "The operating system $(fg_yellow "$os_type") is not supported by this script."
-      ;;
+  Linux)
+    succeeded
+    ;;
+  *)
+    failed
+    error_exit "$LINENO" "The operating system $(fg_yellow "$os_type") is not supported by this script."
+    ;;
   esac
 }
 
 # This will check if the system architecture is supported.
-os_arch_check()
-{
+os_arch_check() {
   info "Checking for valid operating system architecture..."
   arch=$(uname -m)
-  case "$arch" in 
-    x86_64|aarch64|ppc64|ppc64le|arm64|aarch64_be|armv8b|armv8l|arm|armv6l|armv7l)
-      succeeded
-      ;;
-    *)
-      failed
-      error_exit "$LINENO" "The operating system architecture $(fg_yellow "$arch") is not supported by this script."
-      ;;
+  case "$arch" in
+  x86_64 | aarch64 | ppc64 | ppc64le | arm64 | aarch64_be | armv8b | armv8l | arm | armv6l | armv7l)
+    succeeded
+    ;;
+  *)
+    failed
+    error_exit "$LINENO" "The operating system architecture $(fg_yellow "$arch") is not supported by this script."
+    ;;
   esac
 }
 
 # This will check if the current environment has
 # all required shell dependencies to run the installation.
-dependencies_check()
-{
+dependencies_check() {
   info "Checking for script dependencies..."
   FAILED_PREREQS=''
   for prerequisite in $PREREQS; do
@@ -584,31 +560,28 @@ dependencies_check()
 }
 
 # This will check to ensure either dpkg or rpm is installedon the system
-package_type_check()
-{
+package_type_check() {
   info "Checking for package manager..."
-  if command -v dpkg > /dev/null 2>&1; then
-      succeeded
-  elif command -v rpm > /dev/null 2>&1; then
-      succeeded
+  if command -v dpkg >/dev/null 2>&1; then
+    succeeded
+  elif command -v rpm >/dev/null 2>&1; then
+    succeeded
   else
-      failed
-      error_exit "$LINENO" "Could not find dpkg or rpm on the system"
+    failed
+    error_exit "$LINENO" "Could not find dpkg or rpm on the system"
   fi
 }
 
 # latest_version gets the tag of the latest release, without the v prefix.
-latest_version()
-{
-  curl -sSL -H"Accept: application/vnd.github.v3+json" https://api.github.com/repos/observIQ/observiq-otel-collector/releases/latest | \
-    grep "\"tag_name\"" | \
+latest_version() {
+  curl -sSL -H"Accept: application/vnd.github.v3+json" https://api.github.com/repos/observIQ/observiq-otel-collector/releases/latest |
+    grep "\"tag_name\"" |
     sed -r 's/ *"tag_name": "v([0-9]+\.[0-9]+\.[0-9+])",/\1/'
 }
 
 # This will install the package by downloading the archived agent,
 # extracting the binaries, and then removing the archive.
-install_package()
-{
+install_package() {
   banner "Installing BindPlane Agent"
   increase_indent
 
@@ -624,7 +597,7 @@ install_package()
 
     if [ -n "$proxy" ]; then
       info "Downloading package using proxy..."
-    fi 
+    fi
 
     info "Downloading package..."
     eval curl -L "$proxy_args" "$collector_download_url" -o "$out_file_path" --progress-bar --fail || error_exit "$LINENO" "Failed to download package"
@@ -632,10 +605,10 @@ install_package()
   fi
 
   info "Installing package..."
-  # if target install directory doesn't exist and we're using dpkg ensure a clean state 
+  # if target install directory doesn't exist and we're using dpkg ensure a clean state
   # by checking for the package and running purge if it exists.
   if [ ! -d "$INSTALL_DIR" ] && [ "$package_type" = "deb" ]; then
-    dpkg -s "observiq-otel-collector" > /dev/null 2>&1 && dpkg --purge "observiq-otel-collector" > /dev/null 2>&1
+    dpkg -s "observiq-otel-collector" >/dev/null 2>&1 && dpkg --purge "observiq-otel-collector" >/dev/null 2>&1
   fi
 
   unpack_package || error_exit "$LINENO" "Failed to extract package"
@@ -654,28 +627,28 @@ install_package()
       # We'll want to restart, which will start it if it wasn't running already,
       # and restart in the case that this was an upgrade on a running agent.
       info "Restarting service..."
-      systemctl restart observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to restart service"
+      systemctl restart observiq-otel-collector >/dev/null 2>&1 || error_exit "$LINENO" "Failed to restart service"
       succeeded
     else
       info "Enabling service..."
-      systemctl enable --now observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
+      systemctl enable --now observiq-otel-collector >/dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
       succeeded
     fi
   else
     case "$(service observiq-otel-collector status)" in
-      *running*)
-        # The service is running.
-        # We'll want to restart.
-        info "Restarting service..."
-        service observiq-otel-collector restart > /dev/null 2>&1 || error_exit "$LINENO" "Failed to restart service"
-        succeeded
-        ;;
-      *)
-        info "Enabling and starting service..."
-        chkconfig observiq-otel-collector on > /dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
-        service observiq-otel-collector start > /dev/null 2>&1 || error_exit "$LINENO" "Failed to start service"
-        succeeded
-        ;;
+    *running*)
+      # The service is running.
+      # We'll want to restart.
+      info "Restarting service..."
+      service observiq-otel-collector restart >/dev/null 2>&1 || error_exit "$LINENO" "Failed to restart service"
+      succeeded
+      ;;
+    *)
+      info "Enabling and starting service..."
+      chkconfig observiq-otel-collector on >/dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
+      service observiq-otel-collector start >/dev/null 2>&1 || error_exit "$LINENO" "Failed to start service"
+      succeeded
+      ;;
     esac
   fi
 
@@ -683,91 +656,87 @@ install_package()
   decrease_indent
 }
 
-unpack_package()
-{
+unpack_package() {
   case "$package_type" in
-    deb)
-      dpkg --force-confold -i "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
-      ;;
-    rpm)
-      rpm -U "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
-      ;;
-    *)
-      error "Unrecognized package type"
-      return 1
-      ;;
+  deb)
+    dpkg --force-confold -i "$out_file_path" >/dev/null || error_exit "$LINENO" "Failed to unpack package"
+    ;;
+  rpm)
+    rpm -U "$out_file_path" >/dev/null || error_exit "$LINENO" "Failed to unpack package"
+    ;;
+  *)
+    error "Unrecognized package type"
+    return 1
+    ;;
   esac
   return 0
 }
 
 # create_supervisor_config creates the supervisor.yml at the specified path, containing opamp information.
-create_supervisor_config()
-{
+create_supervisor_config() {
   supervisor_yml_path="$1"
   if [ ! -f "$supervisor_yml_path" ]; then
 
     # Note here: We create the file and change permissions of the file here BEFORE writing info to it.
     # We do this because the file contains the secret key.
     # We do not want the file readable by anyone other than root/obseriq-otel-collector.
-    command printf '' >> "$supervisor_yml_path"
+    command printf '' >>"$supervisor_yml_path"
     chown observiq-otel-collector:observiq-otel-collector "$supervisor_yml_path"
     chmod 0600 "$supervisor_yml_path"
 
-    command printf 'server:\n' > "$supervisor_yml_path"
-    command printf '  endpoint: "%s"\n' "$OPAMP_ENDPOINT" >> "$supervisor_yml_path"
-    command printf '  headers:\n' >> "$supervisor_yml_path"
-    [ -n "$OPAMP_SECRET_KEY" ] && command printf '    Authorization: "Secret-Key %s"\n' "$OPAMP_SECRET_KEY" >> "$supervisor_yml_path"
-    command printf '  tls:\n' >> "$supervisor_yml_path"
-    command printf '    insecure: true\n' >> "$supervisor_yml_path"
-    command printf '    insecure_skip_verify: true\n' >> "$supervisor_yml_path"
-    command printf 'capabilities:\n' >> "$supervisor_yml_path"
-    command printf '  accepts_remote_config: true\n' >> "$supervisor_yml_path"
-    command printf '  reports_remote_config: true\n' >> "$supervisor_yml_path"
-    command printf 'agent:\n' >> "$supervisor_yml_path"
+    command printf 'server:\n' >"$supervisor_yml_path"
+    command printf '  endpoint: "%s"\n' "$OPAMP_ENDPOINT" >>"$supervisor_yml_path"
+    command printf '  headers:\n' >>"$supervisor_yml_path"
+    [ -n "$OPAMP_SECRET_KEY" ] && command printf '    Authorization: "Secret-Key %s"\n' "$OPAMP_SECRET_KEY" >>"$supervisor_yml_path"
+    command printf '  tls:\n' >>"$supervisor_yml_path"
+    command printf '    insecure: true\n' >>"$supervisor_yml_path"
+    command printf '    insecure_skip_verify: true\n' >>"$supervisor_yml_path"
+    command printf 'capabilities:\n' >>"$supervisor_yml_path"
+    command printf '  accepts_remote_config: true\n' >>"$supervisor_yml_path"
+    command printf '  reports_remote_config: true\n' >>"$supervisor_yml_path"
+    command printf 'agent:\n' >>"$supervisor_yml_path"
     # TODO(dakota): Add logging config option when supervisor suppports it
-    command printf '  executable: "%s"\n' "$INSTALL_DIR/observiq-otel-collector" >> "$supervisor_yml_path"
-    command printf '  description:\n' >> "$supervisor_yml_path"
-    command printf '    non_identifying_attributes:\n' >> "$supervisor_yml_path"
-    [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >> "$supervisor_yml_path"
-    command printf 'storage:\n' >> "$supervisor_yml_path"
-    command printf '  directory: "%s"\n' "$INSTALL_DIR/supervisor_storage" >> "$supervisor_yml_path"
+    command printf '  executable: "%s"\n' "$INSTALL_DIR/observiq-otel-collector" >>"$supervisor_yml_path"
+    command printf '  description:\n' >>"$supervisor_yml_path"
+    command printf '    non_identifying_attributes:\n' >>"$supervisor_yml_path"
+    [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >>"$supervisor_yml_path"
+    command printf 'storage:\n' >>"$supervisor_yml_path"
+    command printf '  directory: "%s"\n' "$INSTALL_DIR/supervisor_storage" >>"$supervisor_yml_path"
   fi
 }
 
 # This will display the results of an installation
-display_results()
-{
-    banner 'Information'
-    increase_indent
-    info "Agent Home:         $(fg_cyan "$INSTALL_DIR")$(reset)"
-    info "Agent Config:       $(fg_cyan "$INSTALL_DIR/supervisor_storage/config.yaml")$(reset)"
-    info "Agent Logs Command:       $(fg_cyan "sudo tail -F $INSTALL_DIR/supervisor_storage/agent.log")$(reset)"
-    if [ "$SVC_PRE" = "systemctl" ]; then
-      info "Supervisor Start Command:      $(fg_cyan "sudo systemctl start observiq-otel-collector")$(reset)"
-      info "Supervisor Stop Command:       $(fg_cyan "sudo systemctl stop observiq-otel-collector")$(reset)"
-    else
-      info "Supervisor Start Command:      $(fg_cyan "sudo service observiq-otel-collector start")$(reset)"
-      info "Supervisor Stop Command:       $(fg_cyan "sudo service observiq-otel-collector stop")$(reset)"
-    fi
-    decrease_indent
+display_results() {
+  banner 'Information'
+  increase_indent
+  info "Agent Home:         $(fg_cyan "$INSTALL_DIR")$(reset)"
+  info "Agent Config:       $(fg_cyan "$INSTALL_DIR/supervisor_storage/effective.yaml")$(reset)"
+  info "Agent Logs Command:       $(fg_cyan "sudo tail -F $INSTALL_DIR/supervisor_storage/agent.log")$(reset)"
+  if [ "$SVC_PRE" = "systemctl" ]; then
+    info "Supervisor Start Command:      $(fg_cyan "sudo systemctl start observiq-otel-collector")$(reset)"
+    info "Supervisor Stop Command:       $(fg_cyan "sudo systemctl stop observiq-otel-collector")$(reset)"
+  else
+    info "Supervisor Start Command:      $(fg_cyan "sudo service observiq-otel-collector start")$(reset)"
+    info "Supervisor Stop Command:       $(fg_cyan "sudo service observiq-otel-collector stop")$(reset)"
+  fi
+  decrease_indent
 
-    banner 'Support'
-    increase_indent
-    info "For more information on configuring the agent, see the docs:"
-    increase_indent
-    info "$(fg_cyan "https://github.com/observIQ/bindplane-agent/tree/main#bindplane-agent")$(reset)"
-    decrease_indent
-    info "If you have any other questions please contact us at $(fg_cyan support@observiq.com)$(reset)"
-    increase_indent
-    decrease_indent
-    decrease_indent
+  banner 'Support'
+  increase_indent
+  info "For more information on configuring the agent, see the docs:"
+  increase_indent
+  info "$(fg_cyan "https://github.com/observIQ/bindplane-agent/tree/main#bindplane-agent")$(reset)"
+  decrease_indent
+  info "If you have any other questions please contact us at $(fg_cyan support@observiq.com)$(reset)"
+  increase_indent
+  decrease_indent
+  decrease_indent
 
-    banner "$(fg_green Installation Complete!)"
-    return 0
+  banner "$(fg_green Installation Complete!)"
+  return 0
 }
 
-main()
-{
+main() {
   # We do these checks before we process arguments, because
   # some of these options bail early, and we'd like to be sure that those commands
   # (e.g. uninstall) can run
@@ -778,34 +747,58 @@ main()
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do
       case "$1" in
-        -v|--version)
-          version=$2 ; shift 2 ;;
-        -l|--url)
-          url=$2 ; shift 2 ;;
-        -f|--file)
-          package_path=$2 ; shift 2 ;;
-        -x|--proxy)
-          proxy=$2 ; shift 2 ;;
-        -U|--proxy-user)
-          proxy_user=$2 ; shift 2 ;;
-        -P|--proxy-password)
-          proxy_password=$2 ; shift 2 ;;
-        -e|--endpoint)
-          opamp_endpoint=$2 ; shift 2 ;;
-        -k|--labels)
-          opamp_labels=$2 ; shift 2 ;;
-        -s|--secret-key)
-          opamp_secret_key=$2 ; shift 2 ;;
-        -c|--check-bp-url)
-          check_bp_url="true" ; shift 1 ;;
-        -b|--base-url)
-          base_url=$2 ; shift 2 ;;
-        -h|--help)
-          usage
-          exit 0
-          ;;
+      -v | --version)
+        version=$2
+        shift 2
+        ;;
+      -l | --url)
+        url=$2
+        shift 2
+        ;;
+      -f | --file)
+        package_path=$2
+        shift 2
+        ;;
+      -x | --proxy)
+        proxy=$2
+        shift 2
+        ;;
+      -U | --proxy-user)
+        proxy_user=$2
+        shift 2
+        ;;
+      -P | --proxy-password)
+        proxy_password=$2
+        shift 2
+        ;;
+      -e | --endpoint)
+        opamp_endpoint=$2
+        shift 2
+        ;;
+      -k | --labels)
+        opamp_labels=$2
+        shift 2
+        ;;
+      -s | --secret-key)
+        opamp_secret_key=$2
+        shift 2
+        ;;
+      -c | --check-bp-url)
+        check_bp_url="true"
+        shift 1
+        ;;
+      -b | --base-url)
+        base_url=$2
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
       --)
-        shift; break ;;
+        shift
+        break
+        ;;
       *)
         error "Invalid argument: $1"
         usage

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -705,10 +705,11 @@ create_supervisor_config()
   supervisor_yml_path="$1"
   if [ ! -f "$supervisor_yml_path" ]; then
 
-    # Note here: We create the file and change permissions of the file here BEFORE writing info to it
-    # We do this because the file may contain a secret key, so we want 0 window when the
-    # file is readable by anyone other than root
+    # Note here: We create the file and change permissions of the file here BEFORE writing info to it.
+    # We do this because the file contains the secret key.
+    # We do not want the file readable by anyone other than root/obseriq-otel-collector.
     command printf '' >> "$supervisor_yml_path"
+    chown observiq-otel-collector:observiq-otel-collector "$supervisor_yml_path"
     chmod 0600 "$supervisor_yml_path"
 
     command printf 'server:\n' > "$supervisor_yml_path"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -27,7 +27,6 @@ elif command -v service >/dev/null 2>&1; then
 fi
 
 # Script Constants
-COLLECTOR_USER="observiq-otel-collector"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 INSTALL_DIR="/opt/observiq-otel-collector"
 SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor.yaml"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -29,7 +29,8 @@ fi
 # Script Constants
 COLLECTOR_USER="observiq-otel-collector"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
-SUPERVISOR_YML_PATH="/opt/observiq-otel-collector/supervisor.yaml"
+INSTALL_DIR="/opt/observiq-otel-collector"
+SUPERVISOR_YML_PATH="$INSTALL_DIR/supervisor.yaml"
 PREREQS="curl printf $SVC_PRE sed uname cut"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
@@ -633,7 +634,7 @@ install_package()
   info "Installing package..."
   # if target install directory doesn't exist and we're using dpkg ensure a clean state 
   # by checking for the package and running purge if it exists.
-  if [ ! -d "/opt/observiq-otel-collector" ] && [ "$package_type" = "deb" ]; then
+  if [ ! -d "$INSTALL_DIR" ] && [ "$package_type" = "deb" ]; then
     dpkg -s "observiq-otel-collector" > /dev/null 2>&1 && dpkg --purge "observiq-otel-collector" > /dev/null 2>&1
   fi
 
@@ -724,12 +725,12 @@ create_supervisor_config()
     command printf '  reports_remote_config: true\n' >> "$supervisor_yml_path"
     command printf 'agent:\n' >> "$supervisor_yml_path"
     # TODO(dakota): Add logging config option when supervisor suppports it
-    command printf '  executable: "%s"\n' "/opt/observiq-otel-collector/observiq-otel-collector" >> "$supervisor_yml_path"
+    command printf '  executable: "%s"\n' "$INSTALL_DIR/observiq-otel-collector" >> "$supervisor_yml_path"
     command printf '  description:\n' >> "$supervisor_yml_path"
     command printf '    non_identifying_attributes:\n' >> "$supervisor_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >> "$supervisor_yml_path"
     command printf 'storage:\n' >> "$supervisor_yml_path"
-    command printf '  directory: "%s"\n' "/opt/observiq-otel-collector/supervisor_storage" >> "$supervisor_yml_path"
+    command printf '  directory: "%s"\n' "$INSTALL_DIR/supervisor_storage" >> "$supervisor_yml_path"
   fi
 }
 
@@ -738,9 +739,9 @@ display_results()
 {
     banner 'Information'
     increase_indent
-    info "Agent Home:         $(fg_cyan "/opt/observiq-otel-collector")$(reset)"
-    info "Agent Config:       $(fg_cyan "/opt/observiq-otel-collector/supervisor_storage/config.yaml")$(reset)"
-    info "Agent Logs Command:       $(fg_cyan "sudo tail -F /opt/observiq-otel-collector/supervisor_storage/agent.log")$(reset)"
+    info "Agent Home:         $(fg_cyan "$INSTALL_DIR")$(reset)"
+    info "Agent Config:       $(fg_cyan "$INSTALL_DIR/supervisor_storage/config.yaml")$(reset)"
+    info "Agent Logs Command:       $(fg_cyan "sudo tail -F $INSTALL_DIR/supervisor_storage/agent.log")$(reset)"
     if [ "$SVC_PRE" = "systemctl" ]; then
       info "Supervisor Start Command:      $(fg_cyan "sudo systemctl start observiq-otel-collector")$(reset)"
       info "Supervisor Stop Command:       $(fg_cyan "sudo systemctl stop observiq-otel-collector")$(reset)"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -704,7 +704,6 @@ create_supervisor_config()
 {
   supervisor_yml_path="$1"
   if [ ! -f "$supervisor_yml_path" ]; then
-    info "Creating supervisor config..."
 
     # Note here: We create the file and change permissions of the file here BEFORE writing info to it
     # We do this because the file may contain a secret key, so we want 0 window when the
@@ -728,7 +727,6 @@ create_supervisor_config()
     command printf '  executable: "%s"\n' "/opt/observiq-otel-collector/observiq-otel-collector" >> "$supervisor_yml_path"
     command printf 'storage:\n' >> "$supervisor_yml_path"
     command printf '  directory: "%s"\n' "/opt/observiq-otel-collector/storage" >> "$supervisor_yml_path"
-    succeeded
   fi
 }
 

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -729,7 +729,7 @@ create_supervisor_config()
     command printf '    non_identifying_attributes:\n' >> "$supervisor_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf '      service.labels: "%s"\n' "$OPAMP_LABELS" >> "$supervisor_yml_path"
     command printf 'storage:\n' >> "$supervisor_yml_path"
-    command printf '  directory: "%s"\n' "/opt/observiq-otel-collector/storage" >> "$supervisor_yml_path"
+    command printf '  directory: "%s"\n' "/opt/observiq-otel-collector/supervisor_storage" >> "$supervisor_yml_path"
   fi
 }
 
@@ -739,8 +739,8 @@ display_results()
     banner 'Information'
     increase_indent
     info "Agent Home:         $(fg_cyan "/opt/observiq-otel-collector")$(reset)"
-    info "Agent Config:       $(fg_cyan "/opt/observiq-otel-collector/config.yaml")$(reset)"
-    info "Agent Logs Command:       $(fg_cyan "sudo tail -F /opt/observiq-otel-collector/agent.log")$(reset)"
+    info "Agent Config:       $(fg_cyan "/opt/observiq-otel-collector/supervisor_storage/config.yaml")$(reset)"
+    info "Agent Logs Command:       $(fg_cyan "sudo tail -F /opt/observiq-otel-collector/supervisor_storage/agent.log")$(reset)"
     if [ "$SVC_PRE" = "systemctl" ]; then
       info "Supervisor Start Command:      $(fg_cyan "sudo systemctl start observiq-otel-collector")$(reset)"
       info "Supervisor Stop Command:       $(fg_cyan "sudo systemctl stop observiq-otel-collector")$(reset)"

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
 manage_systemd_service() {
@@ -26,7 +25,7 @@ manage_systemd_service() {
 
   echo "configured systemd service"
 
-  cat << EOF
+  cat <<EOF
 
 The "observiq-otel-collector" service has been configured!
 
@@ -63,10 +62,10 @@ manage_sysv_service() {
 
 init_type() {
   # Determine if we need service or systemctl for prereqs
-  if command -v systemctl > /dev/null 2>&1; then
+  if command -v systemctl >/dev/null 2>&1; then
     command printf "systemd"
     return
-  elif command -v service > /dev/null 2>&1; then
+  elif command -v service >/dev/null 2>&1; then
     command printf "service"
     return
   fi
@@ -78,14 +77,15 @@ init_type() {
 manage_service() {
   service_type="$(init_type)"
   case "$service_type" in
-    systemd)
-      manage_systemd_service
-      ;;
-    service)
-      manage_sysv_service
-      ;;
-    *)
-      echo "could not detect init system, skipping service configuration"
+  systemd)
+    manage_systemd_service
+    ;;
+  service)
+    manage_sysv_service
+    ;;
+  *)
+    echo "could not detect init system, skipping service configuration"
+    ;;
   esac
 }
 
@@ -106,6 +106,26 @@ finish_permissions() {
   chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/supervisor_storage/effective.yaml
 }
 
+install() {
+  finish_permissions
+  manage_service
+}
 
-finish_permissions
-manage_service
+# upgrade should perform the same actions as install
+upgrade() {
+  install
+}
+
+action="$1"
+
+case "$action" in
+"0" | "install")
+  install
+  ;;
+"1" | "upgrade")
+  upgrade
+  ;;
+*)
+  install
+  ;;
+esac

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -30,10 +30,10 @@ manage_systemd_service() {
 The "observiq-otel-collector" service has been configured!
 
 The collector's config file can be found here: 
-  /opt/observiq-otel-collector/config.yaml
+  /opt/observiq-otel-collector/supervisor_storage/effective.yaml
 
 To view logs from the collector, run:
-  sudo tail -F /opt/observiq-otel-collector/log/collector.log
+  sudo tail -F /opt/observiq-otel-collector/supervisor_storage/agent.log
 
 For more information on configuring the collector, see the docs:
   https://github.com/observIQ/bindplane-agent/tree/main#observiq-opentelemetry-collector

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -99,8 +99,11 @@ finish_permissions() {
   # This prevents the service (running as root) from assigning ownership to
   # the root user. By doing so, we allow the user to switch to observiq-otel-collector
   # user for 'non root' installs.
-  touch /opt/observiq-otel-collector/log/collector.log
-  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/log/collector.log
+  mkdir -p /opt/observiq-otel-collector/supervisor_storage
+  touch /opt/observiq-otel-collector/supervisor_storage/agent.log
+  touch /opt/observiq-otel-collector/supervisor_storage/effective.yaml
+  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/supervisor_storage/agent.log
+  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/supervisor_storage/effective.yaml
 }
 
 

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -94,16 +94,6 @@ finish_permissions() {
   # We also change the owner of the binary to observiq-otel-collector
   chown -R observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
   chmod 0640 /opt/observiq-otel-collector/plugins/*
-
-  # Initialize the log file to ensure it is owned by observiq-otel-collector.
-  # This prevents the service (running as root) from assigning ownership to
-  # the root user. By doing so, we allow the user to switch to observiq-otel-collector
-  # user for 'non root' installs.
-  mkdir -p /opt/observiq-otel-collector/supervisor_storage
-  touch /opt/observiq-otel-collector/supervisor_storage/agent.log
-  touch /opt/observiq-otel-collector/supervisor_storage/effective.yaml
-  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/supervisor_storage/agent.log
-  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/supervisor_storage/effective.yaml
 }
 
 install() {

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -92,7 +92,11 @@ manage_service() {
 finish_permissions() {
   # Goreleaser does not set plugin file permissions, so do them here
   # We also change the owner of the binary to observiq-otel-collector
-  chown -R observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
+  chown -R observiq-otel-collector:observiq-otel-collector \
+    /opt/observiq-otel-collector/observiq-otel-collector \
+    /opt/observiq-otel-collector/opampsupervisor \
+    /opt/observiq-otel-collector/plugins/*
+
   chmod 0640 /opt/observiq-otel-collector/plugins/*
 }
 

--- a/scripts/package/postremove.sh
+++ b/scripts/package/postremove.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Copyright  observIQ, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+uninstall_package()
+{
+    if command -v dpkg > /dev/null 2>&1; then
+        dpkg -r "observiq-otel-collector" > /dev/null 2>&1
+    elif command -v rpm > /dev/null 2>&1; then
+        rpm -e "observiq-otel-collector" > /dev/null 2>&1
+    else
+        printf "Could not find dpkg or rpm on the system"
+    fi
+}
+
+main()
+{
+    # Removes whole install directory
+    info "Removing installed artifacts..."
+    # This find command gets a list of all artifacts paths except the root directory.
+    FILES=$(cd "/opt/observiq-otel-collector"; find "." -not \( -name "." \))
+    for f in $FILES
+    do
+        rm -rf "/opt/observiq-otel-collector/$f" || {printf "Failed to remove artifact /opt/observiq-otel-collector/$f"; return;}
+    done
+    succeeded
+
+    info "Removing package..."
+    uninstall_package()
+    succeeded
+}

--- a/scripts/package/postremove.sh
+++ b/scripts/package/postremove.sh
@@ -29,16 +29,13 @@ uninstall_package()
 main()
 {
     # Removes whole install directory
-    info "Removing installed artifacts..."
+    printf "Removing installed artifacts..."
     # This find command gets a list of all artifacts paths except the root directory.
     FILES=$(cd "/opt/observiq-otel-collector"; find "." -not \( -name "." \))
     for f in $FILES
     do
-        rm -rf "/opt/observiq-otel-collector/$f" || {printf "Failed to remove artifact /opt/observiq-otel-collector/$f"; return;}
+        rm -rf "/opt/observiq-otel-collector/$f"
     done
-    succeeded
 
-    info "Removing package..."
-    uninstall_package()
-    succeeded
+    printf "Removing package..."
 }

--- a/scripts/package/postremove.sh
+++ b/scripts/package/postremove.sh
@@ -15,27 +15,41 @@
 
 set -e
 
-uninstall_package()
-{
-    if command -v dpkg > /dev/null 2>&1; then
-        dpkg -r "observiq-otel-collector" > /dev/null 2>&1
-    elif command -v rpm > /dev/null 2>&1; then
-        rpm -e "observiq-otel-collector" > /dev/null 2>&1
-    else
-        printf "Could not find dpkg or rpm on the system"
-    fi
+remove() {
+  rm -f /usr/lib/systemd/system/observiq-otel-collector.service || {
+    printf 'failed to remove /usr/lib/systemd/system/observiq-otel-collector.service'
+    return
+  }
+  rm -f /etc/init.d/observiq-otel-collector || {
+    printf 'failed to remove /etc/init.d/observiq-otel-collector'
+    return
+  }
+  rm -f /etc/sysconfig/observiq-otel-collector || {
+    printf 'failed to remove /etc/sysconfig/observiq-otel-collector'
+    return
+  }
+  # remove the entire folder
+  # pkg manager will remove most files but this will delete the remaining
+  rm -rf /opt/observiq-otel-collector || {
+    printf 'failed to remove /opt/observiq-otel-collector'
+    return
+  }
 }
 
-main()
-{
-    # Removes whole install directory
-    printf "Removing installed artifacts..."
-    # This find command gets a list of all artifacts paths except the root directory.
-    FILES=$(cd "/opt/observiq-otel-collector"; find "." -not \( -name "." \))
-    for f in $FILES
-    do
-        rm -rf "/opt/observiq-otel-collector/$f"
-    done
-
-    printf "Removing package..."
+upgrade() {
+  return
 }
+
+action="$1"
+
+case "$action" in
+"0" | "remove")
+  remove
+  ;;
+"1" | "upgrade")
+  upgrade
+  ;;
+*)
+  remove
+  ;;
+esac

--- a/scripts/package/postremove.sh
+++ b/scripts/package/postremove.sh
@@ -18,21 +18,20 @@ set -e
 remove() {
   rm -f /usr/lib/systemd/system/observiq-otel-collector.service || {
     printf 'failed to remove /usr/lib/systemd/system/observiq-otel-collector.service'
-    return
   }
-  rm -f /etc/init.d/observiq-otel-collector || {
-    printf 'failed to remove /etc/init.d/observiq-otel-collector'
-    return
-  }
+
   rm -f /etc/sysconfig/observiq-otel-collector || {
     printf 'failed to remove /etc/sysconfig/observiq-otel-collector'
-    return
   }
+
+  rm -f /etc/init.d/observiq-otel-collector || {
+    printf 'failed to remove /etc/init.d/observiq-otel-collector'
+  }
+
   # remove the entire folder
   # pkg manager will remove most files but this will delete the remaining
   rm -rf /opt/observiq-otel-collector || {
     printf 'failed to remove /opt/observiq-otel-collector'
-    return
   }
 }
 

--- a/scripts/package/preinstall.sh
+++ b/scripts/package/preinstall.sh
@@ -13,21 +13,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -e
 
-username="observiq-otel-collector"
+install() {
+    username="observiq-otel-collector"
 
-if getent group "$username" > /dev/null 2>&1; then
-    echo "Group ${username} already exists."
-else
-    groupadd "$username"
-fi
+    if getent group "$username" >/dev/null 2>&1; then
+        echo "Group ${username} already exists."
+    else
+        groupadd "$username"
+    fi
 
-if id "$username" > /dev/null 2>&1; then
-    echo "User ${username} already exists"
-    exit 0
-else
-    useradd --shell /sbin/nologin --system "$username" -g "$username"
-fi
+    if id "$username" >/dev/null 2>&1; then
+        echo "User ${username} already exists"
+        exit 0
+    else
+        useradd --shell /sbin/nologin --system "$username" -g "$username"
+    fi
+}
 
+# Upgrade should perform the same steps as install
+upgrade() {
+    install
+}
+
+action="$1"
+
+case "$action" in
+"0" | "install")
+    install
+    ;;
+"1" | "upgrade")
+    upgrade
+    ;;
+*)
+    install
+    ;;
+esac

--- a/scripts/package/preremove.sh
+++ b/scripts/package/preremove.sh
@@ -18,22 +18,18 @@ set -e
 handle_systemctl() {
   systemctl stop observiq-otel-collector >/dev/null || {
     printf 'failed to stop service'
-    return
   }
   systemctl disable observiq-otel-collector >/dev/null 2>&1 || {
     printf 'failed to disable service'
-    return
   }
 }
 
 handle_service() {
   service observiq-otel-collector stop || {
     printf 'failed to stop service'
-    return
   }
   chkconfig observiq-otel-collector on >/dev/null 2>&1 || {
     printf 'failed to disable service'
-    return
   }
 }
 

--- a/scripts/package/preremove.sh
+++ b/scripts/package/preremove.sh
@@ -25,17 +25,13 @@ fi
 if [ "$SVC_PRE" = "systemctl" ]; then
     info "Stopping service..."
     systemctl stop observiq-otel-collector > /dev/null || { printf 'failed to stop service'; return; }
-    succeeded
 
     info "Disabling service..."
     systemctl disable observiq-otel-collector > /dev/null 2>&1 || { printf 'failed to disable service'; return; }
-    succeeded
 else
     info "Stopping service..."
     service observiq-otel-collector stop || { printf 'failed to stop service'; return; }
-    succeeded
 
     info "Disabling service..."
     chkconfig observiq-otel-collector on > /dev/null 2>&1 || { printf 'failed to disable service'; return; }
-    succeeded
 fi

--- a/scripts/package/preremove.sh
+++ b/scripts/package/preremove.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Copyright  observIQ, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Determine if we need service or systemctl
+if command -v systemctl > /dev/null 2>&1; then
+  SVC_PRE=systemctl
+elif command -v service > /dev/null 2>&1; then
+  SVC_PRE=service
+fi
+
+if [ "$SVC_PRE" = "systemctl" ]; then
+    info "Stopping service..."
+    systemctl stop observiq-otel-collector > /dev/null || { printf 'failed to stop service'; return; }
+    succeeded
+
+    info "Disabling service..."
+    systemctl disable observiq-otel-collector > /dev/null 2>&1 || { printf 'failed to disable service'; return; }
+    succeeded
+else
+    info "Stopping service..."
+    service observiq-otel-collector stop || { printf 'failed to stop service'; return; }
+    succeeded
+
+    info "Disabling service..."
+    chkconfig observiq-otel-collector on > /dev/null 2>&1 || { printf 'failed to disable service'; return; }
+    succeeded
+fi

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -15,7 +15,7 @@
     <array>
         <string>[INSTALLDIR]opampsupervisor</string>
         <string>--config</string>
-        <string>[INSTALLDIR]supervisor-config.yaml</string>
+        <string>[INSTALLDIR]supervisor.yaml</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -91,7 +91,7 @@ start() {
 
     # NOTE: startproc return 0, even if service is
     # already running to match LSB spec.
-    nohup "$PROGRAM" --config config.yaml > /dev/null 2>&1 &
+    nohup "$PROGRAM" --config supervisor-config.yaml > /dev/null 2>&1 &
 
     # Remember status and be verbose
     rc_status -v

--- a/service/observiq-otel-collector
+++ b/service/observiq-otel-collector
@@ -91,7 +91,7 @@ start() {
 
     # NOTE: startproc return 0, even if service is
     # already running to match LSB spec.
-    nohup "$PROGRAM" --config supervisor-config.yaml > /dev/null 2>&1 &
+    nohup "$PROGRAM" --config supervisor.yaml > /dev/null 2>&1 &
 
     # Remember status and be verbose
     rc_status -v

--- a/service/observiq-otel-collector.service
+++ b/service/observiq-otel-collector.service
@@ -11,7 +11,7 @@ Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
+ExecStart=/opt/observiq-otel-collector/opampsupervisor --config supervisor-config.yaml
 SuccessExitStatus=0
 TimeoutSec=20
 StandardOutput=journal

--- a/service/observiq-otel-collector.service
+++ b/service/observiq-otel-collector.service
@@ -11,7 +11,7 @@ Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
 Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
-ExecStart=/opt/observiq-otel-collector/opampsupervisor --config supervisor-config.yaml
+ExecStart=/opt/observiq-otel-collector/opampsupervisor --config supervisor.yaml
 SuccessExitStatus=0
 TimeoutSec=20
 StandardOutput=journal

--- a/service/sysconfig/observiq-otel-collector
+++ b/service/sysconfig/observiq-otel-collector
@@ -5,7 +5,7 @@
 # shellcheck disable=SC2148,SC2034
 
 # Environment variables
-BINARY=observiq-otel-collector
+BINARY=opampsupervisor
 PROGRAM=/opt/observiq-otel-collector/"$BINARY"
 START_CMD="nohup /opt/observiq-otel-collector/$BINARY > /dev/null 2>&1 &"
 LOCKFILE=/var/lock/"$BINARY"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Updates linux install process to work with ocb and supervisor. Tested with debian, rhel, and ubuntu VMs. 

Linux packages now use pre and post remove scripts to manage uninstallation instead of passing `-r` to the install script. 

Also updates docker images to work as well. For docker images, a config file needs to be volume mounted. This is the command I used:

```
docker run -v ./local/docker-supervisor-config.yaml:/etc/otel/supervisor-config.yaml observiq/bindplane-agent-arm64:1.57.1-minimal
```

Notably, the config file needs to have the agent executable path set as `/collector/observiq-otel-collector`

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
