### PR TITLE
feat(container): Minimal scratch based container image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -413,6 +413,21 @@ dockers:
       - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
 
 docker_manifests:
+  - name_template: "observiq/bindplane-agent:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    image_templates:
+      - "observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/bindplane-agent:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    image_templates:
+      - "ghcr.io/observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "ghcr.io/observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    skip_push: false
   - name_template: "observiq/observiq-otel-collector:latest"
     image_templates:
       - "observiq/observiq-otel-collector-amd64:latest"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -222,6 +222,50 @@ nfpms:
 
 # Build container images with docker buildx (mutli arch builds).
 dockers:
+  - id: scratch-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - collector
+    image_templates:
+      - "observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "ghcr.io/observiq/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    dockerfile: ./docker/Dockerfile.scratch
+    use: buildx
+    build_flag_templates:
+      - "--label=created={{.Date}}"
+      - "--label=title={{.ProjectName}}"
+      - "--label=revision={{.FullCommit}}"
+      - "--label=version={{.Version}}"
+      - "--platform=linux/amd64"
+    extra_files:
+      - plugins
+      - config/example.yaml
+      - config/logging.stdout.yaml
+      - LICENSE
+  - id: scratch-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - collector
+    image_templates:
+      - "observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "ghcr.io/observiq/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+      - "us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-minimal"
+    dockerfile: ./docker/Dockerfile.scratch
+    use: buildx
+    build_flag_templates:
+      - "--label=created={{.Date}}"
+      - "--label=title={{.ProjectName}}"
+      - "--label=revision={{.FullCommit}}"
+      - "--label=version={{.Version}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - plugins
+      - config/example.yaml
+      - config/logging.stdout.yaml
+      - LICENSE
   - id: ubuntu-amd64
     goos: linux
     goarch: amd64

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -1,6 +1,8 @@
-FROM busybox as stage
+FROM alpine as stage
 
 RUN addgroup -S otel && adduser -S otel -G otel
+
+RUN apk update && apk add --no-cache ca-certificates
 
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
@@ -13,17 +15,11 @@ FROM scratch
 
 COPY --from=stage /etc/passwd /etc/passwd
 COPY --from=stage /etc/group /etc/group
+COPY --from=stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=stage --chown=otel:otel /licenses /licenses
 COPY --from=stage --chown=otel:otel /etc/otel /etc/otel
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
-#COPY plugins /etc/otel/plugins
-#COPY config/logging.stdout.yaml /etc/otel/logging.yaml
-#COPY config/example.yaml /etc/otel/config.yaml
-
-#COPY --from=builder /bin/chown /bin/chown
-#RUN /bin/chown -R otel:otel /licenses /collector /etc/otel
-#RUN rm /bin/chown
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -1,0 +1,30 @@
+FROM busybox as stage
+
+RUN addgroup -S otel && adduser -S otel -G otel
+
+RUN mkdir /licenses
+COPY LICENSE /licenses/observiq-otel-collector.license
+
+COPY plugins /etc/otel/plugins
+COPY config/logging.stdout.yaml /etc/otel/logging.yaml
+COPY config/example.yaml /etc/otel/config.yaml
+
+FROM scratch
+
+COPY --from=stage /etc/passwd /etc/passwd
+COPY --from=stage /etc/group /etc/group
+COPY --from=stage --chown=otel:otel /licenses /licenses
+COPY --from=stage --chown=otel:otel /etc/otel /etc/otel
+
+COPY observiq-otel-collector /collector/observiq-otel-collector
+#COPY plugins /etc/otel/plugins
+#COPY config/logging.stdout.yaml /etc/otel/logging.yaml
+#COPY config/example.yaml /etc/otel/config.yaml
+
+#COPY --from=builder /bin/chown /bin/chown
+#RUN /bin/chown -R otel:otel /licenses /collector /etc/otel
+#RUN rm /bin/chown
+
+USER otel
+WORKDIR /etc/otel
+ENTRYPOINT ["/collector/observiq-otel-collector"]

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -1,3 +1,7 @@
+# Alpine is used to stage files and directories that are
+# copied into the scratch image. It is also used to create
+# /etc/passwd and /etc/group files for the otel user. Lastly,
+# Alpine is used to retrieve the CA certificates.
 FROM alpine as stage
 
 RUN addgroup -S otel && adduser -S otel -G otel
@@ -11,6 +15,11 @@ COPY plugins /etc/otel/plugins
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 COPY config/example.yaml /etc/otel/config.yaml
 
+# Scratch images contain nothing by default. The built image
+# will contain only what was copied into it. This means it
+# does not contain utilities like ls, cat, or even a shell.
+# Care must be taken to ensure that the built image contains
+# the required permissions and ca-certificate files.
 FROM scratch
 
 COPY --from=stage /etc/passwd /etc/passwd


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Added a new container build based on [scratch](https://hub.docker.com/_/scratch). Scratch images are empty, containing nothing. The final image will only contain files explicitly copied into the image during the build.

This change is security motivated. Users who do not require systemd (journald receiver) and Java (jmx receiver) can decide to use this image, which has a reduced attack surface. The final image contains a single binary (agent binary), does not contain a shell or any other utilizes that an attacker would look for.

The images are tagged with `major.minor.patch-minimal`. I opted to omit `latest` and did not bother with `major` and `major.minor`. The final images are somewhat small, ~ 240MB vs ~500 for the full image.

```
observiq/bindplane-agent-arm64                                               1.56.0-minimal      235MB
ghcr.io/observiq/bindplane-agent-arm64                                       1.56.0-minimal      235MB
us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-arm64   1.56.0-minimal      235MB
observiq/bindplane-agent-amd64                                               1.56.0-minimal      244MB
ghcr.io/observiq/bindplane-agent-amd64                                       1.56.0-minimal      244MB
us-central1-docker.pkg.dev/observiq-containers/agent/bindplane-agent-amd64   1.56.0-minimal      244MB
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
