### PR TITLE
chore(docker): Use release_deps when copying files to container images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -240,8 +240,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/amd64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
   - id: scratch-arm64
@@ -262,8 +263,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/arm64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
   - id: ubuntu-amd64
@@ -306,8 +308,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/amd64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
       - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
@@ -351,8 +354,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/arm64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
       - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
@@ -379,8 +383,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/amd64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
       - release_deps/opentelemetry-java-contrib-jmx-metrics.jar
@@ -406,8 +411,9 @@ dockers:
       - "--label=version={{.Version}}"
       - "--platform=linux/arm64"
     extra_files:
-      - plugins
-      - config/example.yaml
+      - release_deps/VERSION.txt
+      - release_deps/plugins
+      - release_deps/config.yaml
       - config/logging.stdout.yaml
       - LICENSE
       - release_deps/opentelemetry-java-contrib-jmx-metrics.jar

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -11,9 +11,11 @@ RUN apk update && apk add --no-cache ca-certificates
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
-COPY plugins /etc/otel/plugins
+COPY release_deps/VERSION.txt /etc/otel/VERSION.txt
+
+COPY release_deps/plugins /etc/otel/plugins
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml
-COPY config/example.yaml /etc/otel/config.yaml
+COPY release_deps/config.yaml /etc/otel/config.yaml
 
 # Scratch images contain nothing by default. The built image
 # will contain only what was copied into it. This means it

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -54,15 +54,17 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
+COPY release_deps/VERSION.txt /etc/otel/VERSION.txt
+
 COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
-COPY plugins /etc/otel/plugins
+COPY release_deps/plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 
 # Default config allows the agent to run without an injected config, which is required
 # when connecting to an OpAMP platform.
-COPY config/example.yaml /etc/otel/config.yaml
+COPY release_deps/config.yaml /etc/otel/config.yaml
 
 RUN chown otel:otel \
     /etc/otel/config.yaml \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -55,15 +55,17 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
+COPY release_deps/VERSION.txt /etc/otel/VERSION.txt
+
 COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY release_deps/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
-COPY plugins /etc/otel/plugins
+COPY release_deps/plugins /etc/otel/plugins
 
 COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 
 # Default config allows the agent to run without an injected config, which is required
 # when connecting to an OpAMP platform.
-COPY config/example.yaml /etc/otel/config.yaml
+COPY release_deps/config.yaml /etc/otel/config.yaml
 
 RUN chown otel:otel \
     /etc/otel/config.yaml \


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

- Copy plugins from release_deps
- Copy base config from release_deps
- New: Copy VERSION.txt from release_deps

The logging config and LICENSE will continue to be copied as is. The logging config was built specifically for the container build process.

This is a follow up PR for https://github.com/observIQ/bindplane-agent/pull/1769

Tested by deploying BindPlane managed agents and updating them to use the Ubuntu based image produced by this branch.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
