### PR TITLE
feat(docker): Add BindPlane support to minimal image

### DIFF
--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -8,6 +8,12 @@ RUN addgroup -S -g 10005 otel && adduser -S -u 10005 -G otel otel
 
 RUN apk update && apk add --no-cache ca-certificates
 
+RUN mkdir \
+    /etc/otel \
+    /etc/otel/storage \
+    && chown -R otel:otel /etc/otel \
+    && chmod 0750 /etc/otel/storage
+
 RUN mkdir /licenses
 COPY LICENSE /licenses/observiq-otel-collector.license
 
@@ -29,8 +35,12 @@ COPY --from=stage /etc/group /etc/group
 COPY --from=stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=stage --chown=otel:otel /licenses /licenses
 COPY --from=stage --chown=otel:otel /etc/otel /etc/otel
+COPY --from=stage --chown=otel:otel /etc/otel/storage /etc/otel/storage
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
+
+ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.scratch
+++ b/docker/Dockerfile.scratch
@@ -4,7 +4,7 @@
 # Alpine is used to retrieve the CA certificates.
 FROM alpine as stage
 
-RUN addgroup -S otel && adduser -S otel -G otel
+RUN addgroup -S -g 10005 otel && adduser -S -u 10005 -G otel otel
 
 RUN apk update && apk add --no-cache ca-certificates
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

BindPlane makes several assumptions when deploying Kubernetes agents that need to be implemented in the minimal image.

- Add uid and uid 10005 to minimal container image
- Add `/etc/otel/storage` to minimal container image (Required for some BindPlane resource types)
- Add collector home and collector storage environment variables (Required for some BindPlane resource types)

Tested against latest BindPlane SaaS with all K8s source types
- OTLP
- BindPlane Gateway
- Container Logs
- Kubelet Metrics
- Cluster Events
- Cluster Metrics

I tested:
- Current image
- Switch to ubuntu based image produced by this branch
- Switch to minimal image with produced by this branch
- Switch back to current image

No errors going between them. This includes the required changes on the BindPlane k8s manifests, outside of the scope of this PR.

Also tested locally w/ Linux and Docker. When I run ps, I can see that the collector process is running with the correct UID.
```
10005     622901  0.8  0.1 1468440 136448 pts/0  Ssl+ 17:14   0:00 /collector/observiq-otel-collector
```

Follow up PR for https://github.com/observIQ/bindplane-agent/pull/1769

Based on https://github.com/observIQ/bindplane-agent/pull/1770, merge first.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
