### PR TITLE
feat(release): Sign container images with Cosign

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -606,6 +606,15 @@ signs:
 docker_signs:
   - artifacts: all
     stdin: "{{ .Env.COSIGN_PWD }}"
+    args: [
+      # Default options
+      "sign",
+      "--key=cosign.key",
+      "${artifact}",
+      "--yes",
+      # Additional options
+      "--recursive"
+    ]
     output: true
 
 # https://goreleaser.com/customization/release/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -601,6 +601,13 @@ signs:
       ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: all
 
+# https://goreleaser.com/customization/docker_sign/
+# Uses Cosign by default, signs images and manifests.
+docker_signs:
+  - artifacts: all
+    stdin: "{{ .Env.COSIGN_PWD }}"
+    output: true
+
 # https://goreleaser.com/customization/release/
 release:
   draft: false


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The release process signs artifacts using [Cosign](https://github.com/sigstore/cosign). This PR extends this capability to container images and manifests. This is part of a larger effort to sign all BindPlane related artifacts.

The existing release workflow handles the placement of the private key and private key password. The public key already exists in the repo at `signature/bp_agent_key.pub` per out documentation [here](https://github.com/observIQ/bindplane-agent/blob/release/v1.57.0/docs/verify-signature.md).

### Testing

Testing is only possible when building a full release. I forked the repo and built a tag against my fork. The release passed and the resulting image can be verified with Cosign.

```bash
cosign verify \
  --key signature/bp_agent_key.pub \
  ghcr.io/jsirianni/bindplane-agent-arm64:0.0.2-minimal
```
```
Verification for ghcr.io/jsirianni/bindplane-agent-arm64:0.0.2-minimal --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key

[
  {
    "critical":{
      "identity":{
        "docker-reference":"ghcr.io/jsirianni/bindplane-agent-arm64"
      },
      "image":{
        "docker-manifest-digest":"sha256:820fd206415c6ddc1f95d3147ac7cefdeff634d518300a9d8d0328bbced7bd6c"
      },
      "type":"cosign container image signature"
    },
    "optional":null
  }
]
```

##### Checklist
- [x] Changes are tested
- [x] CI has passed
