### PR TITLE
fix: Fix throughput measurement name changes

### DIFF
--- a/processor/throughputmeasurementprocessor/processor.go
+++ b/processor/throughputmeasurementprocessor/processor.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -46,7 +45,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	meter := mp.Meter("github.com/observiq/bindplane-agent/processor/throughputmeasurementprocessor")
 
 	logSize, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "log_data_size"),
+		metricName("log_data_size"),
 		metric.WithDescription("Size of the log package passed to the processor"),
 		metric.WithUnit("By"),
 	)
@@ -55,7 +54,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	}
 
 	metricSize, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "metric_data_size"),
+		metricName("metric_data_size"),
 		metric.WithDescription("Size of the metric package passed to the processor"),
 		metric.WithUnit("By"),
 	)
@@ -64,7 +63,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	}
 
 	traceSize, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "trace_data_size"),
+		metricName("trace_data_size"),
 		metric.WithDescription("Size of the trace package passed to the processor"),
 		metric.WithUnit("By"),
 	)
@@ -73,7 +72,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	}
 
 	logCount, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "log_count"),
+		metricName("log_count"),
 		metric.WithDescription("Count of the number log records passed to the processor"),
 		metric.WithUnit("{logs}"),
 	)
@@ -82,7 +81,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	}
 
 	datapointCount, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "metric_count"),
+		metricName("metric_count"),
 		metric.WithDescription("Count of the number datapoints passed to the processor"),
 		metric.WithUnit("{datapoints}"),
 	)
@@ -91,7 +90,7 @@ func newThroughputMeasurementProcessor(logger *zap.Logger, mp metric.MeterProvid
 	}
 
 	spanCount, err := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(componentType.String(), "trace_count"),
+		metricName("trace_count"),
 		metric.WithDescription("Count of the number spans passed to the processor"),
 		metric.WithUnit("{spans}"),
 	)
@@ -150,4 +149,8 @@ func (tmp *throughputMeasurementProcessor) processMetrics(ctx context.Context, m
 	}
 
 	return md, nil
+}
+
+func metricName(metric string) string {
+	return fmt.Sprintf("otelcol_processor_throughputmeasurement_%s", metric)
 }

--- a/processor/throughputmeasurementprocessor/processor_test.go
+++ b/processor/throughputmeasurementprocessor/processor_test.go
@@ -65,7 +65,7 @@ func TestProcessor_Logs(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, metric := range sm.Metrics {
 			switch metric.Name {
-			case "processor_throughputmeasurement_log_data_size":
+			case "otelcol_processor_throughputmeasurement_log_data_size":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -75,7 +75,7 @@ func TestProcessor_Logs(t *testing.T) {
 
 				logSize = sum.DataPoints[0].Value
 
-			case "processor_throughputmeasurement_log_count":
+			case "otelcol_processor_throughputmeasurement_log_count":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -128,7 +128,7 @@ func TestProcessor_Metrics(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, metric := range sm.Metrics {
 			switch metric.Name {
-			case "processor_throughputmeasurement_metric_data_size":
+			case "otelcol_processor_throughputmeasurement_metric_data_size":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -138,7 +138,7 @@ func TestProcessor_Metrics(t *testing.T) {
 
 				metricSize = sum.DataPoints[0].Value
 
-			case "processor_throughputmeasurement_metric_count":
+			case "otelcol_processor_throughputmeasurement_metric_count":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -191,7 +191,7 @@ func TestProcessor_Traces(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, metric := range sm.Metrics {
 			switch metric.Name {
-			case "processor_throughputmeasurement_trace_data_size":
+			case "otelcol_processor_throughputmeasurement_trace_data_size":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -201,7 +201,7 @@ func TestProcessor_Traces(t *testing.T) {
 
 				traceSize = sum.DataPoints[0].Value
 
-			case "processor_throughputmeasurement_trace_count":
+			case "otelcol_processor_throughputmeasurement_trace_count":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -261,7 +261,7 @@ func TestProcessor_Logs_TwoInstancesSameID(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, metric := range sm.Metrics {
 			switch metric.Name {
-			case "processor_throughputmeasurement_log_data_size":
+			case "otelcol_processor_throughputmeasurement_log_data_size":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -271,7 +271,7 @@ func TestProcessor_Logs_TwoInstancesSameID(t *testing.T) {
 
 				logSize = sum.DataPoints[0].Value
 
-			case "processor_throughputmeasurement_log_count":
+			case "otelcol_processor_throughputmeasurement_log_count":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 1, len(sum.DataPoints))
 
@@ -335,7 +335,7 @@ func TestProcessor_Logs_TwoInstancesDifferentID(t *testing.T) {
 	for _, sm := range rm.ScopeMetrics {
 		for _, metric := range sm.Metrics {
 			switch metric.Name {
-			case "processor_throughputmeasurement_log_data_size":
+			case "otelcol_processor_throughputmeasurement_log_data_size":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 2, len(sum.DataPoints))
 
@@ -353,7 +353,7 @@ func TestProcessor_Logs_TwoInstancesDifferentID(t *testing.T) {
 					}
 				}
 
-			case "processor_throughputmeasurement_log_count":
+			case "otelcol_processor_throughputmeasurement_log_count":
 				sum := metric.Data.(metricdata.Sum[int64])
 				require.Equal(t, 2, len(sum.DataPoints))
 


### PR DESCRIPTION
### Proposed Change
Due to https://github.com/open-telemetry/opentelemetry-collector/pull/9759, the names for our metrics changed. Because of this, we need to add the "otelcol" prefix manually to the name.

I've ended up hardcoding the prefix we want here instead of relying on the processorhelper logic, it's important that this name stays the same between versions of the agent. 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
