### PR TITLE
chore: use env as default provider (as is heavily recommended)

### DIFF
--- a/collector/settings.go
+++ b/collector/settings.go
@@ -48,6 +48,7 @@ func NewSettings(configPaths []string, version string, loggingOpts []zap.Option,
 				httpsprovider.NewFactory(),
 			},
 			ConverterFactories: []confmap.ConverterFactory{expandconverter.NewFactory()},
+			DefaultScheme:      "env",
 		},
 	}
 

--- a/receiver/pluginreceiver/rendered_config.go
+++ b/receiver/pluginreceiver/rendered_config.go
@@ -105,6 +105,7 @@ func (r *RenderedConfig) GetConfigProviderSettings() (*otelcol.ConfigProviderSet
 				envprovider.NewFactory(),
 			},
 			ConverterFactories: []confmap.ConverterFactory{expandconverter.NewFactory()},
+			DefaultScheme:      "env",
 		},
 	}
 


### PR DESCRIPTION
### Proposed Change
* Switch default provider scheme to `env`. This means `${ENV_VAR}` is treated as an environment variable. This actually has no effect until we remove the env converter, but I wanted to make sure we don't forget to add this. This does not change any existing behavior of the collector.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
