### PR TITLE
fix: Revert goreleaser image signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -603,21 +603,22 @@ signs:
       ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
     artifacts: all
 
+# TODO(dakota): commented out because it is causing release to fail with goreleaser v2... not sure why though
 # https://goreleaser.com/customization/docker_sign/
 # Uses Cosign by default, signs images and manifests.
-docker_signs:
-  - artifacts: all
-    stdin: "{{ .Env.COSIGN_PWD }}"
-    args: [
-      # Default options
-      "sign",
-      "--key=cosign.key",
-      "${artifact}",
-      "--yes",
-      # Additional options
-      "--recursive"
-    ]
-    output: true
+# docker_signs:
+#   - artifacts: all
+#     stdin: "{{ .Env.COSIGN_PWD }}"
+#     args: [
+#       # Default options
+#       "sign",
+#       "--key=cosign.key",
+#       "${artifact}",
+#       "--yes",
+#       # Additional options
+#       "--recursive"
+#     ]
+#     output: true
 
 # https://goreleaser.com/customization/release/
 release:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Comment out `docker_signs` section of goreleaser cfg since goreleaser v2 isn't working with cosign for some reason.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
