### PR TITLE
chore(release): Use 8 core runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   release:
     needs: [build-64bit-msi]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When the release has issues, waiting 1 hour for feedback can be tedious. We have the green light to use larger runners where necessary. If the 8 core runner does not appear to be faster, we can revert this PR.

![Screenshot from 2024-08-20 14-54-15](https://github.com/user-attachments/assets/6bce2b51-9ce7-414c-a6b5-a84204ed1a1e)



##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
