### PR TITLE
chore: Test caching to speed up test action

### DIFF
--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -17,6 +17,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: |
             go.sum
+            **/go.sum
       - name: Build
         run: make build-linux
       - name: Scan Third Party Dependency Licenses
@@ -35,6 +36,7 @@ jobs:
           check-latest: true
           cache-dependency-path: |
             go.sum
+            **/go.sum
       - name: Build
         run: make build-darwin
       - name: Scan Third Party Dependency Licenses
@@ -53,6 +55,7 @@ jobs:
           check-latest: true
           cache-dependency-path: |
             go.sum
+            **/go.sum
       - name: Build
         run: make build-windows
       - name: Scan Third Party Dependency Licenses

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -17,7 +17,6 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: |
             go.sum
-            **/go.sum
       - name: Build
         run: make build-linux
       - name: Scan Third Party Dependency Licenses
@@ -36,7 +35,6 @@ jobs:
           check-latest: true
           cache-dependency-path: |
             go.sum
-            **/go.sum
       - name: Build
         run: make build-darwin
       - name: Scan Third Party Dependency Licenses
@@ -55,7 +53,6 @@ jobs:
           check-latest: true
           cache-dependency-path: |
             go.sum
-            **/go.sum
       - name: Build
         run: make build-windows
       - name: Scan Third Party Dependency Licenses

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            **/go.sum
       - name: Build
         run: make build-linux
       - name: Scan Third Party Dependency Licenses
@@ -31,6 +34,9 @@ jobs:
         with:
           go-version: "1.21"
           check-latest: true
+          cache-dependency-path: |
+            go.sum
+            **/go.sum
       - name: Build
         run: make build-darwin
       - name: Scan Third Party Dependency Licenses
@@ -47,6 +53,9 @@ jobs:
         with:
           go-version: "1.21"
           check-latest: true
+          cache-dependency-path: |
+            go.sum
+            **/go.sum
       - name: Build
         run: make build-windows
       - name: Scan Third Party Dependency Licenses

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            **/go.sum
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: |
             go.sum
-            **/go.sum
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          check-latest: true
-          cache-dependency-path: "**/go.sum"
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
           go-version-file: go.mod
           cache-dependency-path: |
             go.sum
+            **/go.sum
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          check-latest: true
+          cache-dependency-path: "**/go.sum"
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Trying to speed up CI after running into issues with the release and needing to wait on CI. Unfortunately the only real bottle neck is downloading dependencies, so for a single CI run there's not much that can be done. By default, the setup-go action will cache the root go.sum but with this change we're going to also cache nested go.sum files. With some rough testing I found this does speed up CI.

These are the results of some rough testing. In general I think caching the nested go.sum files does improve CI speed but it can definitely vary and this probably isn't definitive (such as windows tests taking longer with nested caching vs just the root).
![image](https://github.com/user-attachments/assets/ae1cdb26-799d-4d92-b8af-7fc882dea988)


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
