### PR TITLE
fix: install_unix.sh breaks with status code 2 in non-interactive environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   release:
     needs: [build-64bit-msi]
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-agent/plugindocgen
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/receiver/pluginreceiver v1.58.0
+	github.com/observiq/bindplane-agent/receiver/pluginreceiver v1.59.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -5,7 +5,7 @@ go 1.21.9
 require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
-	github.com/observiq/bindplane-agent/expr v1.58.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.9.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-agent/exporter/chronicleforwarderexporter
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/expr v1.58.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0

--- a/factories/connectors.go
+++ b/factories/connectors.go
@@ -16,6 +16,7 @@ package factories
 
 import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector"
 	"go.opentelemetry.io/collector/connector"
@@ -27,4 +28,5 @@ var defaultConnectors = []connector.Factory{
 	forwardconnector.NewFactory(),
 	servicegraphconnector.NewFactory(),
 	spanmetricsconnector.NewFactory(),
+	routingconnector.NewFactory(),
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.107.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.107.0

--- a/go.mod
+++ b/go.mod
@@ -5,34 +5,34 @@ go 1.21.9
 require (
 	github.com/google/uuid v1.6.0
 	github.com/mholt/archiver/v3 v3.5.1
-	github.com/observiq/bindplane-agent/exporter/azureblobexporter v1.58.0
-	github.com/observiq/bindplane-agent/exporter/chronicleexporter v1.58.0
-	github.com/observiq/bindplane-agent/exporter/chronicleforwarderexporter v1.58.0
-	github.com/observiq/bindplane-agent/exporter/googlecloudexporter v1.58.0
-	github.com/observiq/bindplane-agent/exporter/googlemanagedprometheusexporter v1.58.0
-	github.com/observiq/bindplane-agent/exporter/snowflakeexporter v1.58.0
-	github.com/observiq/bindplane-agent/internal/report v1.58.0
-	github.com/observiq/bindplane-agent/packagestate v1.58.0
-	github.com/observiq/bindplane-agent/processor/datapointcountprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/logcountprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/logdeduplicationprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/lookupprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/maskprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/metricextractprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/metricstatsprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/removeemptyvaluesprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/resourceattributetransposerprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/samplingprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/spancountprocessor v1.58.0
-	github.com/observiq/bindplane-agent/processor/throughputmeasurementprocessor v1.58.0
-	github.com/observiq/bindplane-agent/receiver/awss3rehydrationreceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/azureblobrehydrationreceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/httpreceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/m365receiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/pluginreceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/routereceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/sapnetweaverreceiver v1.58.0
-	github.com/observiq/bindplane-agent/receiver/telemetrygeneratorreceiver v1.58.0
+	github.com/observiq/bindplane-agent/exporter/azureblobexporter v1.59.0
+	github.com/observiq/bindplane-agent/exporter/chronicleexporter v1.59.0
+	github.com/observiq/bindplane-agent/exporter/chronicleforwarderexporter v1.59.0
+	github.com/observiq/bindplane-agent/exporter/googlecloudexporter v1.59.0
+	github.com/observiq/bindplane-agent/exporter/googlemanagedprometheusexporter v1.59.0
+	github.com/observiq/bindplane-agent/exporter/snowflakeexporter v1.59.0
+	github.com/observiq/bindplane-agent/internal/report v1.59.0
+	github.com/observiq/bindplane-agent/packagestate v1.59.0
+	github.com/observiq/bindplane-agent/processor/datapointcountprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/logcountprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/logdeduplicationprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/lookupprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/maskprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/metricextractprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/metricstatsprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/removeemptyvaluesprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/resourceattributetransposerprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/samplingprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/spancountprocessor v1.59.0
+	github.com/observiq/bindplane-agent/processor/throughputmeasurementprocessor v1.59.0
+	github.com/observiq/bindplane-agent/receiver/awss3rehydrationreceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/azureblobrehydrationreceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/httpreceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/m365receiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/pluginreceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/routereceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/sapnetweaverreceiver v1.59.0
+	github.com/observiq/bindplane-agent/receiver/telemetrygeneratorreceiver v1.59.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.107.0
@@ -331,8 +331,8 @@ require (
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/observiq/bindplane-agent/counter v1.58.0 // indirect
-	github.com/observiq/bindplane-agent/expr v1.58.0 // indirect
+	github.com/observiq/bindplane-agent/counter v1.59.0 // indirect
+	github.com/observiq/bindplane-agent/expr v1.59.0 // indirect
 	github.com/observiq/bindplane-agent/internal/rehydration v1.54.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.107.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.107.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1908,6 +1908,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnect
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector v0.107.0/go.mod h1:Fz1oG0B2AVwSAG22GOZc9EGpOXqdHJtYU0F0+KjA6zs=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.107.0 h1:5nCidAaa6vxj85UHOz7/kqtVsnbFMXyDDUV0Ima8FHk=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.107.0/go.mod h1:X+V2G++oM4NHchq7RR4kpL32zKzd6fH4QQzO7/F8i24=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.107.0 h1:jS6ACtJreXaDLG/zp90goLERgsrj4vQrGKZNiFBKGho=
+github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.107.0/go.mod h1:uZus6WqY8aYfns2J2fZrFyyyBNZX7Ghi7s7wSc/02Kw=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.107.0 h1:llpmzV6B3ayRns2O2VUvnmQhBmFYea6B9G/j3TubjnM=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.107.0/go.mod h1:vG1hP4f3oLQI4qCm58GiCXm4X0QiKLojybCM9vqeFXc=
 github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.107.0 h1:1S+oa3bMVrSi7PclgMvxtyPAi8mTdHsuDqAq8XA06qU=

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-agent/internal/rehydration
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/internal/testutils v1.58.0
+	github.com/observiq/bindplane-agent/internal/testutils v1.59.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0
 	go.opentelemetry.io/collector/consumer v0.107.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-agent/processor/datapointcountprocessor
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/counter v1.58.0
-	github.com/observiq/bindplane-agent/expr v1.58.0
-	github.com/observiq/bindplane-agent/receiver/routereceiver v1.58.0
+	github.com/observiq/bindplane-agent/counter v1.59.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
+	github.com/observiq/bindplane-agent/receiver/routereceiver v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-agent/processor/logcountprocessor
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/counter v1.58.0
-	github.com/observiq/bindplane-agent/expr v1.58.0
-	github.com/observiq/bindplane-agent/receiver/routereceiver v1.58.0
+	github.com/observiq/bindplane-agent/counter v1.59.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
+	github.com/observiq/bindplane-agent/receiver/routereceiver v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -3,8 +3,8 @@ module github.com/observiq/bindplane-agent/processor/metricextractprocessor
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/expr v1.58.0
-	github.com/observiq/bindplane-agent/receiver/routereceiver v1.58.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
+	github.com/observiq/bindplane-agent/receiver/routereceiver v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.107.0
 	github.com/stretchr/testify v1.9.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-agent/processor/snapshotprocessor
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/internal/report v1.58.0
+	github.com/observiq/bindplane-agent/internal/report v1.59.0
 	github.com/open-telemetry/opamp-go v0.15.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampcustommessages v0.107.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.107.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -3,9 +3,9 @@ module github.com/observiq/bindplane-agent/processor/spancountprocessor
 go 1.21.9
 
 require (
-	github.com/observiq/bindplane-agent/counter v1.58.0
-	github.com/observiq/bindplane-agent/expr v1.58.0
-	github.com/observiq/bindplane-agent/receiver/routereceiver v1.58.0
+	github.com/observiq/bindplane-agent/counter v1.59.0
+	github.com/observiq/bindplane-agent/expr v1.59.0
+	github.com/observiq/bindplane-agent/receiver/routereceiver v1.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.107.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/observiq/bindplane-agent/internal/rehydration v1.54.0
-	github.com/observiq/bindplane-agent/internal/testutils v1.58.0
+	github.com/observiq/bindplane-agent/internal/testutils v1.59.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0
 	go.opentelemetry.io/collector/confmap v0.107.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -5,7 +5,7 @@ go 1.21.9
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0
 	github.com/observiq/bindplane-agent/internal/rehydration v1.54.0
-	github.com/observiq/bindplane-agent/internal/testutils v1.58.0
+	github.com/observiq/bindplane-agent/internal/testutils v1.59.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.107.0
 	go.opentelemetry.io/collector/confmap v0.107.0

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -35,33 +35,40 @@ SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
 
+IS_INTERACTIVE="false"
+case "$-" in
+  *i*) IS_INTERACTIVE="true" ;;
+esac
+
 # out_file_path is the full path to the downloaded package (e.g. "/tmp/observiq-otel-collector_linux_amd64.deb")
 out_file_path="unknown"
 
-# Colors
-num_colors=$(tput colors 2>/dev/null)
-if test -n "$num_colors" && test "$num_colors" -ge 8; then
-  bold="$(tput bold)"
-  underline="$(tput smul)"
-  # standout can be bold or reversed colors dependent on terminal
-  standout="$(tput smso)"
-  reset="$(tput sgr0)"
-  bg_black="$(tput setab 0)"
-  bg_blue="$(tput setab 4)"
-  bg_cyan="$(tput setab 6)"
-  bg_green="$(tput setab 2)"
-  bg_magenta="$(tput setab 5)"
-  bg_red="$(tput setab 1)"
-  bg_white="$(tput setab 7)"
-  bg_yellow="$(tput setab 3)"
-  fg_black="$(tput setaf 0)"
-  fg_blue="$(tput setaf 4)"
-  fg_cyan="$(tput setaf 6)"
-  fg_green="$(tput setaf 2)"
-  fg_magenta="$(tput setaf 5)"
-  fg_red="$(tput setaf 1)"
-  fg_white="$(tput setaf 7)"
-  fg_yellow="$(tput setaf 3)"
+if $IS_INTERACTIVE; then
+  # Colors
+  num_colors=$(tput colors 2>/dev/null)
+  if test -n "$num_colors" && test "$num_colors" -ge 8; then
+    bold="$(tput bold)"
+    underline="$(tput smul)"
+    # standout can be bold or reversed colors dependent on terminal
+    standout="$(tput smso)"
+    reset="$(tput sgr0)"
+    bg_black="$(tput setab 0)"
+    bg_blue="$(tput setab 4)"
+    bg_cyan="$(tput setab 6)"
+    bg_green="$(tput setab 2)"
+    bg_magenta="$(tput setab 5)"
+    bg_red="$(tput setab 1)"
+    bg_white="$(tput setab 7)"
+    bg_yellow="$(tput setab 3)"
+    fg_black="$(tput setaf 0)"
+    fg_blue="$(tput setaf 4)"
+    fg_cyan="$(tput setaf 6)"
+    fg_green="$(tput setaf 2)"
+    fg_magenta="$(tput setaf 5)"
+    fg_red="$(tput setaf 1)"
+    fg_white="$(tput setaf 7)"
+    fg_yellow="$(tput setaf 3)"
+  fi
 fi
 
 if [ -z "$reset" ]; then
@@ -328,6 +335,11 @@ set_proxy()
     info "Using proxy from arguments: $proxy"
     if [ -n "$proxy_user" ]; then
       while [ -z "$proxy_password" ] ; do
+        if ! $IS_INTERACTIVE; then 
+          error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+          exit
+        fi
+
         increase_indent
         command printf "${indent}$(fg_blue "$proxy_user@$proxy")'s password: "
         stty -echo

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -4,7 +4,7 @@ go 1.21.9
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
-	github.com/observiq/bindplane-agent/packagestate v1.58.0
+	github.com/observiq/bindplane-agent/packagestate v1.59.0
 	github.com/open-telemetry/opamp-go v0.9.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
### Proposed Change
The script "install_unix.sh" was not working in non-interactive shells, because there are tools used (stty and tput) for which a connected tty is mandatory. This is being fixed by a sh-compliant way of checking if the `$-` contains the `i`-flag.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
