### PR TITLE
fix(chronicleforwardexporter): Escape newlines in body that is a string

### DIFF
--- a/exporter/chronicleforwarderexporter/marshal_test.go
+++ b/exporter/chronicleforwarderexporter/marshal_test.go
@@ -140,6 +140,24 @@ func TestMarshalRawLogs(t *testing.T) {
 			rawLogField: `attributes["nonexistent"]`,
 			wantErr:     true,
 		},
+		{
+			name: "String body with newline character",
+			logRecords: []plog.LogRecord{
+				mockLogRecord(t, "Test \nbody", map[string]any{"key1": "value1"}),
+			},
+			expected:    []string{`{"attributes":{"key1":"value1"},"body":"Test \\nbody","resource_attributes":{}}`},
+			rawLogField: "",
+			wantErr:     false,
+		},
+		{
+			name: "Does not affect already escaped newline characters in string body",
+			logRecords: []plog.LogRecord{
+				mockLogRecord(t, "Test\\n \nbody", map[string]any{"key1": "value1"}),
+			},
+			expected:    []string{`{"attributes":{"key1":"value1"},"body":"Test\\n \\nbody","resource_attributes":{}}`},
+			rawLogField: "",
+			wantErr:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->



### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
