### PR TITLE
chore: Disable confmap featuregate

### DIFF
--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -31,9 +31,6 @@ func SetFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.mtimeSortType", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
 	}
-	if err := featuregate.GlobalRegistry().Set("confmap.strictlyTypedInput", false); err != nil {
-		return fmt.Errorf("failed to disable confmap.strictlyTypedInput: %w", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Disable the `confmap.strictlyTypedInput` featuregate (needs to be done before v0.110.0 of OTel).

Ran into issues while updating OTel a few releases ago but no issues disabling now. I think there was some overlap with the environment var expansion feature gate stuff that was causing this one to fail too (issue [here](https://github.com/open-telemetry/opentelemetry-collector/issues/10552) goes into more detail). Now that the env var stuff is taken care disabling this featuregate seems fine.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
