### PR TITLE
fix(plugin): Tomcat plugin has been failing to parse catalina logs due to a bad regex

### DIFF
--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -114,7 +114,7 @@ template: |
           to: attributes.raw_log
         {{ end }}
         - type: regex_parser
-          regex: '(?P<timestamp>\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2}.\d{3})\s(?P<tomcat_severity>\w+)\s\[(?P<thread>[^\[\]]+)(\[[\d:]+\])?\]\s(?P<tc_source>[^ ]+)\s(?P<message>[\s\S]+)'
+          regex: '(?P<timestamp>\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2}.\d{3})\s(?P<tomcat_severity>\w+)\s\[(?P<thread>[^\[\]]+(?:\[[\d:]+\])?)\]\s(?P<tc_source>[^ ]+)\s(?P<message>[\s\S]+)'
           parse_to: {{ .parse_to }}
           timestamp:
             parse_from: {{ .parse_to }}.timestamp

--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -103,7 +103,7 @@ template: |
         {{ end }}
       start_at: {{ .start_at }}
       multiline:
-        line_start_pattern: '[0-9]{2}-[A-Za-z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}'
+        line_start_pattern: '\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2}.\d{3}'
       attributes:
         log_type: tomcat.catalina
       operators:
@@ -114,7 +114,7 @@ template: |
           to: attributes.raw_log
         {{ end }}
         - type: regex_parser
-          regex: '(?P<timestamp>[0-9]{2}-[A-Za-z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})\s(?P<tomcat_severity>[A-Z]*)\s\[(?P<thread>[\w-]*)\]\s(?P<tc_source>[^ ]*)\s(?P<message>[\s\S]+)'
+          regex: '(?P<timestamp>\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2}.\d{3})\s(?P<tomcat_severity>\w+)\s\[(?P<thread>[^\[\]]+)(\[[\d:]+\])?\]\s(?P<tc_source>[^ ]+)\s(?P<message>[\s\S]+)'
           parse_to: {{ .parse_to }}
           timestamp:
             parse_from: {{ .parse_to }}.timestamp


### PR DESCRIPTION
### Proposed Change
The Tomcat source in BindPlane has been failing to parse catalina logs for a few users. After some investigation I found that we had a bad regex for parsing. It was missing an optional subfield, and was also less efficient than it could be. This PR changes it to take account of the optional subfield while also being more efficient.

Regex 101 test here. Change the [\s\S]+ to .+ to validate the subfield parsing (that \s\S pattern captures too much in regex101, but works correctly in BP Agent)
https://regex101.com/r/s4Cuth/3

##### Checklist
- [X] Changes are tested
- [x] CI has passed
