### PR TITLE
feat: add webhook event receiver to build

### DIFF
--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -2,8 +2,8 @@
 
 Below is a list of supported receivers with links to their documentation pages.
 
-| Name                                       | GitHub README                                                                                                                                                      |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Name                                       | GitHub README                                                                                                                                                       |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Active Directory Domain Services Receiver  | [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/activedirectorydsreceiver/README.md)           |
 | Aerospike Receiver                         | [aerospikereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/aerospikereceiver/README.md)                           |
 | Apache CouchDB Receiver                    | [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/couchdbreceiver/README.md)                               |
@@ -15,10 +15,10 @@ Below is a list of supported receivers with links to their documentation pages.
 | AWS CloudWatch Container Insights Receiver | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/awscontainerinsightreceiver/README.md)       |
 | AWS ECS Container Metrics Receiver         | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/awsecscontainermetricsreceiver/README.md) |
 | AWS Kinesis Data Firehose Receiver         | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/awsfirehosereceiver/README.md)                       |
-| AWS S3 Rehydration Receiver                | [awss3rehydrationreceiver](../receiver/awss3rehydrationreceiver/README.md)                                                                                         |
+| AWS S3 Rehydration Receiver                | [awss3rehydrationreceiver](../receiver/awss3rehydrationreceiver/README.md)                                                                                          |
 | AWS X-Ray Receiver                         | [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/awsxrayreceiver/README.md)                               |
 | Azure Blob Receiver                        | [azureblobreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/azureblobreceiver/README.md)                           |
-| Azure Blob Rehydration Receiver            | [azureblobrehydration](../receiver/azureblobrehydrationreceiver/README.md)                                                                                         |
+| Azure Blob Rehydration Receiver            | [azureblobrehydration](../receiver/azureblobrehydrationreceiver/README.md)                                                                                          |
 | Azure Event Hub Receiver                   | [azureeventhubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/azureeventhubreceiver/README.md)                   |
 | Carbon Receiver                            | [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/carbonreceiver/README.md)                                 |
 | Cloudflare Receiver                        | [cloudflarereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/cloudflarereceiver/README.md)                         |
@@ -31,7 +31,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Fluentd Forward Receiver                   | [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/fluentforwardreceiver/README.md)                   |
 | Google Cloud Pub/Sub Receiver              | [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/googlecloudpubsubreceiver/README.md)           |
 | Google Cloud Spanner Receiver              | [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/googlecloudspannerreceiver/README.md)         |
-| HTTP Log Receiver                          | [httpreceiver](../receiver/httpreceiver/README.md)                                                                                                                 |
+| HTTP Log Receiver                          | [httpreceiver](../receiver/httpreceiver/README.md)                                                                                                                  |
 | Host Metrics Receiver                      | [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/hostmetricsreceiver/README.md)                       |
 | HTTP Check Receiver                        | [httpcheckreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/httpcheckreceiver/README.md)                           |
 | InfluxDB Receiver                          | [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/influxdbreceiver/README.md)                             |
@@ -44,17 +44,17 @@ Below is a list of supported receivers with links to their documentation pages.
 | Kafka Receiver                             | [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/kafkareceiver/README.md)                                   |
 | Kafka Metrics Receiver                     | [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/kafkametricsreceiver/README.md)                     |
 | Memcached Receiver                         | [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/memcachedreceiver/README.md)                           |
-| Microsoft 365 Receiver                     | [m365receiver](../receiver/m365receiver/README.md)                                                                                                                 |
+| Microsoft 365 Receiver                     | [m365receiver](../receiver/m365receiver/README.md)                                                                                                                  |
 | Microsoft IIS Receiver                     | [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/iisreceiver/README.md)                                       |
 | Microsoft SQL Server Receiver              | [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/sqlserverreceiver/README.md)                           |
 | MongoDB Receiver                           | [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/mongodbreceiver/README.md)                               |
 | MongoDB Atlas Receiver                     | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/mongodbatlasreceiver/README.md)                     |
 | MySQL Receiver                             | [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/mysqlreceiver/README.md)                                   |
 | NGINX Receiver                             | [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/nginxreceiver/README.md)                                   |
-| Okta Receiver                              | [oktareceiver](../receiver/oktareceiver/README.md)                                                                                                                 |
+| Okta Receiver                              | [oktareceiver](../receiver/oktareceiver/README.md)                                                                                                                  |
 | OpenCensus Receiver                        | [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/opencensusreceiver/README.md)                         |
 | OTLP Receiver                              | [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.108.0/receiver/otlpreceiver/README.md)                                             |
-| Plugin Receiver                            | [pluginreceiver](../receiver/pluginreceiver/README.md)                                                                                                             |
+| Plugin Receiver                            | [pluginreceiver](../receiver/pluginreceiver/README.md)                                                                                                              |
 | Podman Stats Receiver                      | [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/podmanreceiver/README.md)                                 |
 | PostgreSQL Receiver                        | [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/postgresqlreceiver/README.md)                         |
 | Prometheus Receiver                        | [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/prometheusreceiver/README.md)                         |
@@ -62,9 +62,9 @@ Below is a list of supported receivers with links to their documentation pages.
 | RabbitMQ Receiver                          | [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/rabbitmqreceiver/README.md)                             |
 | Redis Receiver                             | [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/redisreceiver/README.md)                                   |
 | Riak Receiver                              | [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/riakreceiver/README.md)                                     |
-| Route Receiver                             | [routereceiver](../receiver/routereceiver/README.md)                                                                                                               |
+| Route Receiver                             | [routereceiver](../receiver/routereceiver/README.md)                                                                                                                |
 | SAP Hana Receiver                          | [saphanamreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/saphanareceiver)                                        |
-| SAP Netweaver Receiver                     | [sapnetweaverreceiver](../receiver/sapnetweaverreceiver/README.md)                                                                                                 |
+| SAP Netweaver Receiver                     | [sapnetweaverreceiver](../receiver/sapnetweaverreceiver/README.md)                                                                                                  |
 | SAPM Receiver                              | [sapmreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/sapmreceiver/README.md)                                     |
 | SNMP Receiver                              | [snmpreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/snmpreceiver/README.md)                                     |
 | Splunk HEC Receiver                        | [splunkhecreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/splunkhecreceiver/README.md)                           |
@@ -74,6 +74,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | TCP Log Receiver                           | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/tcplogreceiver/README.md)                                 |
 | UDP Log Receiver                           | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/udplogreceiver/README.md)                                 |
 | vCenter Receiver                           | [vcenterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/vcenterreceiver/README.md)                               |
+| Webhook Event Receiver                     | [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/webhookeventreceiver/README.md)                  |
 | Windows Event Log Receiver                 | [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/windowseventlogreceiver/README.md)               |
 | Windows Performance Counters Receiver      | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/windowsperfcountersreceiver/README.md)       |
 | Zipkin Receiver                            | [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.108.0/receiver/zipkinreceiver/README.md)                                 |

--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -84,6 +84,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
@@ -165,6 +166,7 @@ var defaultReceivers = []receiver.Factory{
 	telemetrygeneratorreceiver.NewFactory(),
 	udplogreceiver.NewFactory(),
 	vcenterreceiver.NewFactory(),
+	webhookeventreceiver.NewFactory(),
 	windowseventlogreceiver.NewFactory(),
 	windowsperfcountersreceiver.NewFactory(),
 	zipkinreceiver.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.108.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.108.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.108.0
@@ -326,6 +327,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
+	github.com/julienschmidt/httprouter v1.3.0 // indirect
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1689,6 +1689,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -2235,6 +2236,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceive
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.108.0/go.mod h1:0UvvQOtgYZv8yreuWBXplgtUcPtyfUwXR8QPjgmUMkI=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.108.0 h1:+u3nesW4wJjrCnLCJQRSYnS8bpRiO26rqhgIQKAY4Zg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.108.0/go.mod h1:GSnt/hbtU9zsiCJjLFOzrMoOISstaeMr9buI7snesuc=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.108.0 h1:4KUn9jbhOX0WeYPZ5rUkA5kYJyySdd2aJA/lE4utedg=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.108.0/go.mod h1:aRgGTQmjMFaEAS8MdXZz2aVeBcoQ95MyYYOmxIEkHtQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.108.0 h1:1YVu/rWE2olP0KR64D0RBIHBqJYjrgTZP8Jky17dX0I=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver v0.108.0/go.mod h1:sclSr05jixEy6Hr+Y/9BFPMKhp2cs1Z5dWoklnyYaD4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.108.0 h1:NPsrXiGlF/LrY1MM6DBp5UNKORPJpWnPHlozdnd1grU=


### PR DESCRIPTION
### Proposed Change
* Adds the [webhook event receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/webhookeventreceiver)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
