### PR TITLE
feat: Make Windows dir admin only

### DIFF
--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -274,6 +274,7 @@
          {{range $i, $e := .Shortcuts}}
          <ComponentRef Id="ApplicationShortcuts{{$i}}"/>
          {{end}}
+         <ComponentRef Id="ProductFolder"/>
       </Feature>
 
       <UI>

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -72,6 +72,12 @@
 
         <Directory Id="$(var.Program_Files)">
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
+                <Component Id="ProductFolder" Guid="*">
+                    <CreateFolder>
+                        <Permission User="Administrators" GenericAll="yes" />
+                        <Permission User="Users" GenericAll="no" />
+                    </CreateFolder>
+                </Component>
                 {{define "FILES"}}
                 {{range $f := .}}
                 <Component 

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -72,7 +72,7 @@
 
         <Directory Id="$(var.Program_Files)">
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
-                <Component Id="ProductFolder" Guid="*">
+                <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
                         <Permission User="Administrators" GenericAll="yes" />
                         <Permission User="Users" GenericAll="no" />


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
When installing on windows with the MSI, the collector's folder should only be accessible by administrators. Added new permission settings to the WIX file.

Addresses an issue Travis put in the triage: https://linear.app/observiq/issue/BPOP-709/agent-windows-agent-folder-restrict-permissions-to-administrator

<img width="778" alt="Screenshot 2024-09-04 at 8 54 01 AM" src="https://github.com/user-attachments/assets/2a561af8-ebc6-4ca6-8472-4c24c3097cfb">


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
