### PR TITLE
fix: Call shutdown on storage extension

### DIFF
--- a/receiver/m365receiver/logs.go
+++ b/receiver/m365receiver/logs.go
@@ -140,7 +140,13 @@ func (l *m365LogsReceiver) Shutdown(ctx context.Context) error {
 		l.cancel()
 	}
 	l.wg.Wait()
-	return l.checkpoint(ctx)
+
+	err := l.checkpoint(ctx)
+	if err != nil {
+		l.logger.Error("failed checkpoint", zap.Error(err))
+	}
+
+	return l.storageClient.Close(ctx)
 }
 
 // spins a go routine at each poll interval to go get logs


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Shutdown should be calling shutdown on the storage extension. When it doesn't, the next start up fails because it cannot connect to the file extension. 

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
