### PR TITLE
fix: add ottl metric condition to expr package for use in sampling processor

### DIFF
--- a/expr/ottl.go
+++ b/expr/ottl.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 )
@@ -34,6 +35,20 @@ func NewOTTLSpanStatement(statementStr string, set component.TelemetrySettings) 
 		return nil, err
 	}
 
+	statement, err := parser.ParseStatement(statementStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return statement, nil
+}
+
+// NewOTTLMetricStatement parses the given statement into an ottl.Statement for a metric transform context.
+func NewOTTLMetricStatement(statementStr string, set component.TelemetrySettings) (*ottl.Statement[ottlmetric.TransformContext], error) {
+	parser, err := ottlmetric.NewParser(functions[ottlmetric.TransformContext](), set)
+	if err != nil {
+		return nil, err
+	}
 	statement, err := parser.ParseStatement(statementStr)
 	if err != nil {
 		return nil, err

--- a/expr/ottl_condition.go
+++ b/expr/ottl_condition.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"go.opentelemetry.io/collector/component"
 )
@@ -44,6 +45,19 @@ func NewOTTLSpanCondition(condition string, set component.TelemetrySettings) (*O
 	}
 
 	return &OTTLCondition[ottlspan.TransformContext]{
+		statement: statement,
+	}, nil
+}
+
+// NewOTTLMetricCondition creates a new OTTLCondition for a metric with the given condition.
+func NewOTTLMetricCondition(condition string, set component.TelemetrySettings) (*OTTLCondition[ottlmetric.TransformContext], error) {
+	statementStr := "noop() where " + condition
+	statement, err := NewOTTLMetricStatement(statementStr, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OTTLCondition[ottlmetric.TransformContext]{
 		statement: statement,
 	}, nil
 }

--- a/expr/ottl_expression.go
+++ b/expr/ottl_expression.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"go.opentelemetry.io/collector/component"
 )
@@ -47,6 +48,21 @@ func NewOTTLSpanExpression(expression string, set component.TelemetrySettings) (
 	}
 
 	return &OTTLExpression[ottlspan.TransformContext]{
+		statement: statement,
+	}, nil
+}
+
+// NewOTTLMetricExpression creates a new expression for metrics.
+// The expression is wrapped in an editor function, so only Converter functions and target expressions can be used.
+func NewOTTLMetricExpression(expression string, set component.TelemetrySettings) (*OTTLExpression[ottlmetric.TransformContext], error) {
+	// Wrap the expression in the "value" function, since the ottl grammar expects a function first.
+	statementStr := fmt.Sprintf("value(%s)", expression)
+	statement, err := NewOTTLMetricStatement(statementStr, set)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OTTLExpression[ottlmetric.TransformContext]{
 		statement: statement,
 	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -346,7 +346,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/observiq/bindplane-agent/counter v1.61.0 // indirect
 	github.com/observiq/bindplane-agent/expr v1.61.0 // indirect
-	github.com/observiq/bindplane-agent/internal/rehydration v1.60.0 // indirect
+	github.com/observiq/bindplane-agent/internal/rehydration v1.61.0 // indirect
 	github.com/okta/okta-sdk-golang/v2 v2.20.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.109.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension v0.109.0 // indirect

--- a/processor/samplingprocessor/config.go
+++ b/processor/samplingprocessor/config.go
@@ -36,9 +36,5 @@ func (cfg Config) Validate() error {
 		return errInvalidDropRatio
 	}
 
-	if cfg.Condition == "" {
-		cfg.Condition = "true"
-	}
-
 	return nil
 }

--- a/processor/samplingprocessor/config.go
+++ b/processor/samplingprocessor/config.go
@@ -36,5 +36,9 @@ func (cfg Config) Validate() error {
 		return errInvalidDropRatio
 	}
 
+	if cfg.Condition == "" {
+		cfg.Condition = "true"
+	}
+
 	return nil
 }

--- a/processor/samplingprocessor/factory.go
+++ b/processor/samplingprocessor/factory.go
@@ -96,7 +96,7 @@ func createMetricsProcessor(
 	nextConsumer consumer.Metrics,
 ) (processor.Metrics, error) {
 	oCfg := cfg.(*Config)
-	condition, err := expr.NewOTTLDatapointCondition(oCfg.Condition, set.TelemetrySettings)
+	condition, err := expr.NewOTTLMetricCondition(oCfg.Condition, set.TelemetrySettings)
 	if err != nil {
 		return nil, fmt.Errorf("invalid condition: %w", err)
 	}

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/bindplane-agent/processor/samplingprocessor
 go 1.22.6
 
 require (
-	github.com/observiq/bindplane-agent/expr v1.60.0
+	github.com/observiq/bindplane-agent/expr v1.61.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.109.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.109.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -50,3 +50,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/observiq/bindplane-agent/expr => ../../expr

--- a/processor/samplingprocessor/go.sum
+++ b/processor/samplingprocessor/go.sum
@@ -55,8 +55,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/observiq/bindplane-agent/expr v1.60.0 h1:KAzOTgFtwSNJa90gg4TrZzQ2v4h7C+FvgEFwiRXak7U=
-github.com/observiq/bindplane-agent/expr v1.60.0/go.mod h1:0YAhrdXeOAjgZJiIJfWh+Pcj4iIAolxZ7EHbqC2g3mM=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.109.0 h1:4VBRgtyh3hHSgAVGgs4bvNwJd0oUGyxVA3eQO2ujNsA=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.109.0/go.mod h1:9MGQCqxdCNBhdD+7QBZ6hH9HipXe5CajMafVKglD5f0=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.109.0 h1:k7uHhrznH4dYvzbaCRz5VgFyHzhd1NGow1s6504r6tA=

--- a/processor/samplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/processor_test.go
@@ -248,7 +248,7 @@ func Test_processMetrics(t *testing.T) {
 		},
 		{
 			desc:      "multiple metrics condition",
-			condition: `(metric.name == "m1")`,
+			condition: `(name == "m1")`,
 			dropRatio: 1.0,
 			input:     multipleMetrics,
 			expected:  multipleMetricsResult,
@@ -262,7 +262,7 @@ func Test_processMetrics(t *testing.T) {
 				Condition: tc.condition,
 			}
 
-			ottlCondition, err := expr.NewOTTLDatapointCondition(cfg.Condition, component.TelemetrySettings{Logger: zap.NewNop()})
+			ottlCondition, err := expr.NewOTTLMetricCondition(cfg.Condition, component.TelemetrySettings{Logger: zap.NewNop()})
 			require.NoError(t, err)
 
 			processor := newMetricsSamplingProcessor(zap.NewNop(), cfg, ottlCondition)

--- a/processor/samplingprocessor/processor_test.go
+++ b/processor/samplingprocessor/processor_test.go
@@ -31,10 +31,6 @@ func Test_processTraces(t *testing.T) {
 	td := ptrace.NewTraces()
 	td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
 
-	emptySpan := ptrace.NewTraces()
-	emptySpan.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
-	emptySpan.ResourceSpans().At(0).ScopeSpans().At(0).Spans().RemoveIf(func(_ ptrace.Span) bool { return true })
-
 	multipleSpansInput := ptrace.NewTraces()
 	multipleSpansInput.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
 	multipleSpansInput.ResourceSpans().At(0).ScopeSpans().At(0).Spans().AppendEmpty()
@@ -57,7 +53,7 @@ func Test_processTraces(t *testing.T) {
 			condition: "true",
 			dropRatio: 1.0,
 			input:     td,
-			expected:  emptySpan,
+			expected:  ptrace.NewTraces(),
 		},
 		{
 			desc:      "Never Drop true",
@@ -110,9 +106,6 @@ func Test_processTraces(t *testing.T) {
 func Test_processLogs(t *testing.T) {
 	ld := plog.NewLogs()
 	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	emptyLogRecords := plog.NewLogs()
-	emptyLogRecords.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	emptyLogRecords.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().RemoveIf(func(_ plog.LogRecord) bool { return true })
 
 	multipleRecordsInput := plog.NewLogs()
 	multipleRecordsInput.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
@@ -139,7 +132,7 @@ func Test_processLogs(t *testing.T) {
 			dropRatio: 1.0,
 			condition: "true",
 			input:     ld,
-			expected:  emptyLogRecords,
+			expected:  plog.NewLogs(),
 		},
 		{
 			desc:      "Never Drop true",
@@ -195,12 +188,6 @@ func Test_processMetrics(t *testing.T) {
 	metric.SetEmptyGauge()
 	metric.Gauge().DataPoints().AppendEmpty()
 
-	emptyMetrics := pmetric.NewMetrics()
-	em := emptyMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	em.SetEmptyGauge()
-	em.Gauge().DataPoints().AppendEmpty()
-	emptyMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().RemoveIf(func(_ pmetric.Metric) bool { return true })
-
 	multipleMetrics := pmetric.NewMetrics()
 	m1 := multipleMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 	m2 := multipleMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
@@ -223,7 +210,7 @@ func Test_processMetrics(t *testing.T) {
 			condition: "true",
 			dropRatio: 1.0,
 			input:     md,
-			expected:  emptyMetrics,
+			expected:  pmetric.NewMetrics(),
 		},
 		{
 			desc:      "Never Drop true",

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
-	github.com/observiq/bindplane-agent/internal/rehydration v1.60.0
+	github.com/observiq/bindplane-agent/internal/rehydration v1.61.0
 	github.com/observiq/bindplane-agent/internal/testutils v1.61.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.109.0

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.22.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0
-	github.com/observiq/bindplane-agent/internal/rehydration v1.60.0
+	github.com/observiq/bindplane-agent/internal/rehydration v1.61.0
 	github.com/observiq/bindplane-agent/internal/testutils v1.61.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.109.0


### PR DESCRIPTION
### Proposed Change
Adds OTTL Metric Condition, Statement, and Expression to the expr package. Changes the sampling processor to use a metric based condition instead of datapoint based condition.

Followup to: #1877 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
