### PR TITLE
feat: Allow metric conversion functions on datapoint and metric context

### DIFF
--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -31,10 +31,6 @@ func SetFeatureFlags() error {
 	if err := featuregate.GlobalRegistry().Set("filelog.mtimeSortType", true); err != nil {
 		return fmt.Errorf("failed to enable filelog.mtimeSortType: %w", err)
 	}
-	// Temporary while we get some interoperability into BPOP
-	if err := featuregate.GlobalRegistry().Set("processor.transform.ConvertBetweenSumAndGaugeMetricContext", false); err != nil {
-		return fmt.Errorf("failed to enable processor.transform.ConvertBetweenSumAndGaugeMetricContext: %w", err)
-	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -864,3 +864,7 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 // replace pkg/stanza with this commit until dan's pr is merged
 // https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35175
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => github.com/observIQ/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20240917140935-2741093f40aa
+
+// Replace transformprocessor so that metric conversion functions are temporarily available on both the metric and datapoint context.
+// We will remove this in v1.63.0 of the agent and switch over to only having the conversion functions on the metric context.
+replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.110.0 => github.com/observiq/opentelemetry-collector-contrib/processor/transformprocessor v0.0.0-20240927124052-b041923b94a1

--- a/go.sum
+++ b/go.sum
@@ -1880,6 +1880,8 @@ github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7o
 github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
 github.com/observIQ/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20240917140935-2741093f40aa h1:8CxUu9d9sfWIDYSQZbXm1nzqyrW2O3ULcxhUs/dYzZw=
 github.com/observIQ/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20240917140935-2741093f40aa/go.mod h1:/cJjT1Tsh3onIjeZlKH4Tc94HOvs7gDcdDwK3KKRUC4=
+github.com/observiq/opentelemetry-collector-contrib/processor/transformprocessor v0.0.0-20240927124052-b041923b94a1 h1:JP2rgNyjjgN4sQd9XtuQKjPoh+ZAUjiX/NI7hFMslII=
+github.com/observiq/opentelemetry-collector-contrib/processor/transformprocessor v0.0.0-20240927124052-b041923b94a1/go.mod h1:cPBwwiLx37z3wmsYFD/xJLnMsDNyIkuQMDMsxlabAgw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -2126,8 +2128,6 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocesso
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.110.0/go.mod h1:VSufsKGLHC2FwRtxjSJyt/Q+p+s27GHJ15AtGUTMhgg=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.110.0 h1:bnzvE7VXMssr9uSWM0it5QQNvHxypvkGXyELSBBXuU8=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.110.0/go.mod h1:fMbX6TkiafPxvoBZTJNbFXSBS1eBCyEru4squ0SmVcM=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.110.0 h1:7qIVo3gsBbNITaW1aWItNkDnFk/5TEb69MeQRZpSxSY=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.110.0/go.mod h1:cPBwwiLx37z3wmsYFD/xJLnMsDNyIkuQMDMsxlabAgw=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.110.0 h1:oDK8IyYtxRDHR7S9lTMVXJOG3MwwN77+6AY91eq1D54=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.110.0/go.mod h1:PFw6bvmWPcLrBb3HQXWejkbmcALRuFFaPNDCFQJlCVQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.110.0 h1:/jE3efLqX/PGagn3oixwyhHHzQVx0O+0zQdjKzJY8QE=


### PR DESCRIPTION
### Proposed Change
* Allow datapoint and metric context to convert between sum and gauge

You can see the diff here: https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/v0.110.0...observIQ:opentelemetry-collector-contrib:fix/v0.110.0-transform-processor-interop?expand=1

Tested with this sample config:
```yaml
receivers:
  hostmetrics:
    collection_interval: 60s
    scrapers:
      load:
        metrics: null

processors:
  transform:
    metric_statements:
      - context: metric
        statements:
          - convert_gauge_to_sum("cumulative", false)
          - convert_sum_to_gauge()
      - context: datapoint
        statements:
          - convert_gauge_to_sum("cumulative", false)
          - convert_sum_to_gauge()

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    logs:
      receivers: [hostmetrics]
      processors: [transform]
      exporters: [debug]
```

Here, both contexts have the convert functions, so you can use them in either. We need this for BPOP to be able to upgrade the agent properly.

We plan to remove this in v1.63.0, at which point we should only support using the metric context for these functions.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
