### PR TITLE
feat(install): Add quiet flag to allow use in non-interactive shells

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -297,7 +297,7 @@ interactive_check()
   if [ "$non_interactive" = "true" ] && [ "$check_bp_url" = "true" ]
   then 
     failed
-    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+    error_exit "$LINENO" "Checking the BindPlane server URL is not compatible with quiet (non-interactive) mode."
   fi
 }
 

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -28,10 +28,11 @@ SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
 non_interactive=false
+error_mode=false
 
 
 # Colors
-if [ "$non_interactive" = "true" ]; then
+if [ "$non_interactive" = "false" ]; then
   num_colors=$(tput colors 2>/dev/null)
   if test -n "$num_colors" && test "$num_colors" -ge 8; then
     bold="$(tput bold)"
@@ -66,12 +67,14 @@ fi
 
 # Helper Functions
 printf() {
-  if command -v sed >/dev/null; then
-    command printf -- "$@" | sed -E "$sed_ignore s/^/$indent/g"  # Ignore sole reset characters if defined
-  else
-    # Ignore $* suggestion as this breaks the output
-    # shellcheck disable=SC2145
-    command printf -- "$indent$@"
+  if [ "$non_interactive" = "false" ] || [ "$error_mode" = "true" ]; then
+    if command -v sed >/dev/null; then
+      command printf -- "$@" | sed -E "$sed_ignore s/^/$indent/g"  # Ignore sole reset characters if defined
+    else
+      # Ignore $* suggestion as this breaks the output
+      # shellcheck disable=SC2145
+      command printf -- "$indent$@"
+    fi
   fi
 }
 
@@ -116,7 +119,9 @@ warn() {
 # shellcheck disable=SC2059
 error() {
   increase_indent
+  error_mode=true
   printf "$fg_red$*$reset\\n"
+  error_mode=false
   decrease_indent
 }
 # Intentionally using variables in format string
@@ -134,15 +139,17 @@ prompt() {
 
 bindplane_banner()
 {
-  fg_cyan " oooooooooo.   o8o                    .o8  ooooooooo.   oooo\\n"
-  fg_cyan " '888'   '88b  '\"'                   \"888  '888   'Y88. '888\\n" 
-  fg_cyan "  888     888 oooo  ooo. .oo.    .oooo888   888   .d88'  888   .oooo.   ooo. .oo.    .ooooo.\\n"
-  fg_cyan "  888oooo888' '888  '888P\"Y88b  d88' '888   888ooo88P'   888  'P  )88b  '888P\"Y88b  d88' '88b\\n" 
-  fg_cyan "  888    '88b  888   888   888  888   888   888          888   .oP\"888   888   888  888ooo888\\n"
-  fg_cyan "  888    .88P  888   888   888  888   888   888          888  d8(  888   888   888  888    .o\\n"
-  fg_cyan " o888bood8P'  o888o o888o o888o 'Y8bod88P\" o888o        o888o 'Y888\"\"8o o888o o888o '88bod8P'\\n"
+  if [ "$non_interactive" = "false" ]; then
+    fg_cyan " oooooooooo.   o8o                    .o8  ooooooooo.   oooo\\n"
+    fg_cyan " '888'   '88b  '\"'                   \"888  '888   'Y88. '888\\n" 
+    fg_cyan "  888     888 oooo  ooo. .oo.    .oooo888   888   .d88'  888   .oooo.   ooo. .oo.    .ooooo.\\n"
+    fg_cyan "  888oooo888' '888  '888P\"Y88b  d88' '888   888ooo88P'   888  'P  )88b  '888P\"Y88b  d88' '88b\\n" 
+    fg_cyan "  888    '88b  888   888   888  888   888   888          888   .oP\"888   888   888  888ooo888\\n"
+    fg_cyan "  888    .88P  888   888   888  888   888   888          888  d8(  888   888   888  888    .o\\n"
+    fg_cyan " o888bood8P'  o888o o888o o888o 'Y8bod88P\" o888o        o888o 'Y888\"\"8o o888o o888o '88bod8P'\\n"
 
-  reset
+    reset
+  fi
 }
 
 separator() { printf "===================================================\\n" ; }
@@ -629,6 +636,7 @@ display_results()
 
 uninstall()
 {
+  bindplane_banner
   banner "Uninstalling BindPlane Agent"
   increase_indent
 

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -636,7 +636,6 @@ display_results()
 
 uninstall()
 {
-  bindplane_banner
   banner "Uninstalling BindPlane Agent"
   increase_indent
 

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -283,6 +283,17 @@ check_prereqs()
   decrease_indent
 }
 
+# Test non-interactive mode compatibility
+interactive_check()
+{
+  # Incompatible with checking the BP url since it can be interactive on failed connection
+  if [ "$non_interactive" = "true" ] && [ "$check_bp_url" = "true" ]
+  then 
+    failed
+    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+  fi
+}
+
 # Test connection to BindPlane if it was specified
 connection_check()
 {
@@ -712,6 +723,7 @@ main()
     done
   fi
 
+  interactive_check
   connection_check
   setup_installation
   install_package

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -27,32 +27,35 @@ MANAGEMENT_YML_PATH="$INSTALL_DIR/manager.yaml"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
+non_interactive=false
 
 
 # Colors
-num_colors=$(tput colors 2>/dev/null)
-if test -n "$num_colors" && test "$num_colors" -ge 8; then
-  bold="$(tput bold)"
-  underline="$(tput smul)"
-  # standout can be bold or reversed colors dependent on terminal
-  standout="$(tput smso)"
-  reset="$(tput sgr0)"
-  bg_black="$(tput setab 0)"
-  bg_blue="$(tput setab 4)"
-  bg_cyan="$(tput setab 6)"
-  bg_green="$(tput setab 2)"
-  bg_magenta="$(tput setab 5)"
-  bg_red="$(tput setab 1)"
-  bg_white="$(tput setab 7)"
-  bg_yellow="$(tput setab 3)"
-  fg_black="$(tput setaf 0)"
-  fg_blue="$(tput setaf 4)"
-  fg_cyan="$(tput setaf 6)"
-  fg_green="$(tput setaf 2)"
-  fg_magenta="$(tput setaf 5)"
-  fg_red="$(tput setaf 1)"
-  fg_white="$(tput setaf 7)"
-  fg_yellow="$(tput setaf 3)"
+if [ "$non_interactive" = "true" ]; then
+  num_colors=$(tput colors 2>/dev/null)
+  if test -n "$num_colors" && test "$num_colors" -ge 8; then
+    bold="$(tput bold)"
+    underline="$(tput smul)"
+    # standout can be bold or reversed colors dependent on terminal
+    standout="$(tput smso)"
+    reset="$(tput sgr0)"
+    bg_black="$(tput setab 0)"
+    bg_blue="$(tput setab 4)"
+    bg_cyan="$(tput setab 6)"
+    bg_green="$(tput setab 2)"
+    bg_magenta="$(tput setab 5)"
+    bg_red="$(tput setab 1)"
+    bg_white="$(tput setab 7)"
+    bg_yellow="$(tput setab 3)"
+    fg_black="$(tput setaf 0)"
+    fg_blue="$(tput setaf 4)"
+    fg_cyan="$(tput setaf 6)"
+    fg_green="$(tput setaf 2)"
+    fg_magenta="$(tput setaf 5)"
+    fg_red="$(tput setaf 1)"
+    fg_white="$(tput setaf 7)"
+    fg_yellow="$(tput setaf 3)"
+  fi
 fi
 
 if [ -z "$reset" ]; then
@@ -201,6 +204,9 @@ Usage:
     Check access to the BindPlane server URL.
 
     This parameter will have the script check access to BindPlane based on the provided '--endpoint'
+
+  $(fg_yellow '-q, --quiet')
+    Use quiet (non-interactive) mode to run the script in headless environments
 
 EOF
   )
@@ -671,6 +677,8 @@ main()
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do
       case "$1" in
+        -q|--quiet)
+          non_interactive="true" ; shift 1 ;;
         -l|--url)
           url=$2 ; shift 2 ;;
         -v|--version)

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -801,8 +801,6 @@ uninstall_package()
 
 uninstall()
 {
-  bindplane_banner
-
   set_package_type
   banner "Uninstalling BindPlane Agent"
   increase_indent

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -34,34 +34,37 @@ PREREQS="curl printf $SVC_PRE sed uname cut"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
+non_interactive=false
 
 # out_file_path is the full path to the downloaded package (e.g. "/tmp/observiq-otel-collector_linux_amd64.deb")
 out_file_path="unknown"
 
 # Colors
-num_colors=$(tput colors 2>/dev/null)
-if test -n "$num_colors" && test "$num_colors" -ge 8; then
-  bold="$(tput bold)"
-  underline="$(tput smul)"
-  # standout can be bold or reversed colors dependent on terminal
-  standout="$(tput smso)"
-  reset="$(tput sgr0)"
-  bg_black="$(tput setab 0)"
-  bg_blue="$(tput setab 4)"
-  bg_cyan="$(tput setab 6)"
-  bg_green="$(tput setab 2)"
-  bg_magenta="$(tput setab 5)"
-  bg_red="$(tput setab 1)"
-  bg_white="$(tput setab 7)"
-  bg_yellow="$(tput setab 3)"
-  fg_black="$(tput setaf 0)"
-  fg_blue="$(tput setaf 4)"
-  fg_cyan="$(tput setaf 6)"
-  fg_green="$(tput setaf 2)"
-  fg_magenta="$(tput setaf 5)"
-  fg_red="$(tput setaf 1)"
-  fg_white="$(tput setaf 7)"
-  fg_yellow="$(tput setaf 3)"
+if [ "$non_interactive" = "true" ]; then
+  num_colors=$(tput colors 2>/dev/null)
+  if test -n "$num_colors" && test "$num_colors" -ge 8; then
+    bold="$(tput bold)"
+    underline="$(tput smul)"
+    # standout can be bold or reversed colors dependent on terminal
+    standout="$(tput smso)"
+    reset="$(tput sgr0)"
+    bg_black="$(tput setab 0)"
+    bg_blue="$(tput setab 4)"
+    bg_cyan="$(tput setab 6)"
+    bg_green="$(tput setab 2)"
+    bg_magenta="$(tput setab 5)"
+    bg_red="$(tput setab 1)"
+    bg_white="$(tput setab 7)"
+    bg_yellow="$(tput setab 3)"
+    fg_black="$(tput setaf 0)"
+    fg_blue="$(tput setaf 4)"
+    fg_cyan="$(tput setaf 6)"
+    fg_green="$(tput setaf 2)"
+    fg_magenta="$(tput setaf 5)"
+    fg_red="$(tput setaf 1)"
+    fg_white="$(tput setaf 7)"
+    fg_yellow="$(tput setaf 3)"
+  fi
 fi
 
 if [ -z "$reset" ]; then
@@ -220,6 +223,9 @@ Usage:
     Check access to the BindPlane server URL.
 
     This parameter will have the script check access to BindPlane based on the provided '--endpoint'
+
+  $(fg_yellow '-q, --quiet')
+    Use quiet (non-interactive) mode to run the script in headless environments
 
 EOF
   )
@@ -504,6 +510,7 @@ check_prereqs()
   banner "Checking Prerequisites"
   increase_indent
   root_check
+  proxy_check
   os_check
   os_arch_check
   package_type_check
@@ -520,6 +527,15 @@ root_check()
   then
     failed
     error_exit "$LINENO" "Script needs to be run as root or with sudo"
+  fi
+}
+
+proxy_check()
+{
+  if [ "$non_interactive" = "true" ] && [ -z "$proxy_password" ]
+  then 
+    failed
+    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
   fi
 }
 
@@ -823,6 +839,8 @@ main()
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do
       case "$1" in
+        -q|--quiet)
+          non_interactive="true" ; shift 1 ;;
         -v|--version)
           version=$2 ; shift 2 ;;
         -l|--url)

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -510,7 +510,6 @@ check_prereqs()
   banner "Checking Prerequisites"
   increase_indent
   root_check
-  proxy_check
   os_check
   os_arch_check
   package_type_check
@@ -530,9 +529,18 @@ root_check()
   fi
 }
 
-proxy_check()
+# Test non-interactive mode compatibility
+interactive_check()
 {
+  # Incompatible with proxies unless both username and password are passed
   if [ "$non_interactive" = "true" ] && [ -z "$proxy_password" ]
+  then 
+    failed
+    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+  fi
+
+  # Incompatible with checking the BP url since it can be interactive on failed connection
+  if [ "$non_interactive" = "true" ] && [ "$check_bp_url" = "true" ]
   then 
     failed
     error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
@@ -882,6 +890,7 @@ main()
     done
   fi
 
+  interactive_check
   connection_check
   setup_installation
   install_package

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -35,12 +35,13 @@ SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
 non_interactive=false
+error_mode=false
 
 # out_file_path is the full path to the downloaded package (e.g. "/tmp/observiq-otel-collector_linux_amd64.deb")
 out_file_path="unknown"
 
 # Colors
-if [ "$non_interactive" = "true" ]; then
+if [ "$non_interactive" = "false" ]; then
   num_colors=$(tput colors 2>/dev/null)
   if test -n "$num_colors" && test "$num_colors" -ge 8; then
     bold="$(tput bold)"
@@ -75,12 +76,14 @@ fi
 
 # Helper Functions
 printf() {
-  if command -v sed >/dev/null; then
-    command printf -- "$@" | sed -r "$sed_ignore s/^/$indent/g"  # Ignore sole reset characters if defined
-  else
-    # Ignore $* suggestion as this breaks the output
-    # shellcheck disable=SC2145
-    command printf -- "$indent$@"
+  if [ "$non_interactive" = "false" ] || [ "$error_mode" = "true" ]; then
+    if command -v sed >/dev/null; then
+      command printf -- "$@" | sed -r "$sed_ignore s/^/$indent/g"  # Ignore sole reset characters if defined
+    else
+      # Ignore $* suggestion as this breaks the output
+      # shellcheck disable=SC2145
+      command printf -- "$indent$@"
+    fi
   fi
 }
 
@@ -125,7 +128,9 @@ warn() {
 # shellcheck disable=SC2059
 error() {
   increase_indent
+  error_mode=true
   printf "$fg_red$*$reset\\n"
+  error_mode=false
   decrease_indent
 }
 # Intentionally using variables in format string
@@ -143,15 +148,17 @@ prompt() {
 
 bindplane_banner()
 {
-  fg_cyan " oooooooooo.   o8o                    .o8  ooooooooo.   oooo\\n"
-  fg_cyan " '888'   '88b  '\"'                   \"888  '888   'Y88. '888\\n" 
-  fg_cyan "  888     888 oooo  ooo. .oo.    .oooo888   888   .d88'  888   .oooo.   ooo. .oo.    .ooooo.\\n"
-  fg_cyan "  888oooo888' '888  '888P\"Y88b  d88' '888   888ooo88P'   888  'P  )88b  '888P\"Y88b  d88' '88b\\n" 
-  fg_cyan "  888    '88b  888   888   888  888   888   888          888   .oP\"888   888   888  888ooo888\\n"
-  fg_cyan "  888    .88P  888   888   888  888   888   888          888  d8(  888   888   888  888    .o\\n"
-  fg_cyan " o888bood8P'  o888o o888o o888o 'Y8bod88P\" o888o        o888o 'Y888\"\"8o o888o o888o '88bod8P'\\n"
+  if [ "$non_interactive" = "false" ]; then
+    fg_cyan " oooooooooo.   o8o                    .o8  ooooooooo.   oooo\\n"
+    fg_cyan " '888'   '88b  '\"'                   \"888  '888   'Y88. '888\\n" 
+    fg_cyan "  888     888 oooo  ooo. .oo.    .oooo888   888   .d88'  888   .oooo.   ooo. .oo.    .ooooo.\\n"
+    fg_cyan "  888oooo888' '888  '888P\"Y88b  d88' '888   888ooo88P'   888  'P  )88b  '888P\"Y88b  d88' '88b\\n" 
+    fg_cyan "  888    '88b  888   888   888  888   888   888          888   .oP\"888   888   888  888ooo888\\n"
+    fg_cyan "  888    .88P  888   888   888  888   888   888          888  d8(  888   888   888  888    .o\\n"
+    fg_cyan " o888bood8P'  o888o o888o o888o 'Y8bod88P\" o888o        o888o 'Y888\"\"8o o888o o888o '88bod8P'\\n"
 
-  reset
+    reset
+  fi
 }
 
 separator() { printf "===================================================\\n" ; }

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -540,17 +540,17 @@ root_check()
 interactive_check()
 {
   # Incompatible with proxies unless both username and password are passed
-  if [ "$non_interactive" = "true" ] && [ -z "$proxy_password" ]
+  if [ "$non_interactive" = "true" ] && [ -n "$proxy_password" ]
   then 
     failed
-    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively."
   fi
 
   # Incompatible with checking the BP url since it can be interactive on failed connection
   if [ "$non_interactive" = "true" ] && [ "$check_bp_url" = "true" ]
   then 
     failed
-    error_exit "$LINENO" "The proxy password must be set via the command line argument -P, if called non-interactively!"
+    error_exit "$LINENO" "Checking the BindPlane server URL is not compatible with quiet (non-interactive) mode."
   fi
 }
 


### PR DESCRIPTION
### Proposed Change
Add a new quiet flag that allows running this script in a non-interactive shell, including performing a prerequisite check that prevents running when interactive features are required.

##### Checklist
- [X] Changes are tested
- [x] CI has passed
