### PR TITLE
fix: Fix build for supervisor in 2.0

### DIFF
--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -47,8 +47,6 @@ for PLATFORM in "${PLATFORMS[@]}"; do
         EXT=""
     fi
     echo "Building supervisor for $GOOS/$GOARCH"
-    GOOS="$GOOS" GOARCH="$GOARCH" go build main.go
-    cp main${EXT} $PROJECT_BASE/$DOWNLOAD_DIR/supervisor_bin/opampsupervisor_${GOOS}_${GOARCH}${EXT}
-    rm main${EXT}
+    GOOS="$GOOS" GOARCH="$GOARCH" go build -o $PROJECT_BASE/$DOWNLOAD_DIR/supervisor_bin/opampsupervisor_${GOOS}_${GOARCH}${EXT} .
 done
 $(cd $PROJECT_BASE/$DOWNLOAD_DIR && rm -rf opentelemetry-collector-contrib)


### PR DESCRIPTION
### Proposed Change
Supervisor build should build the supervisor package, not the main.go. Due to a recent change where multiple go files were introduced, the supervisor build broke. This fixes that by building the package (`.`) instead of `main.go`.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
