### PR TITLE
chore: Don't require OpAMP endpoint when installing & starting

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -188,6 +188,12 @@ nfpms:
         dst: /opt/observiq-otel-collector/plugins
       # Storage dir is used by stateful receivers, such as filelog receiver. It allows
       # receivers to track their progress and buffer data.
+      - src: config/supervisor-default.yaml
+        dst: /opt/observiq-otel-collector/supervisor.yaml
+        file_info:
+          mode: 0750
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
       - dst: /opt/observiq-otel-collector/storage
         type: dir
         file_info:

--- a/config/supervisor-default.yaml
+++ b/config/supervisor-default.yaml
@@ -1,0 +1,12 @@
+server:
+  endpoint: ws://localhost:3001/v1/opamp
+
+capabilities:
+  accepts_remote_config: true
+  reports_remote_config: true
+
+agent:
+  executable: "./observiq-otel-collector"
+
+storage:
+  directory: "./supervisor_storage"

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -28,6 +28,9 @@ SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
 
+# Default Supervisor Config Hash
+DEFAULT_SUPERVISOR_CFG_HASH="ac4e6001f1b19d371bba6a2797ba0a55d7ca73151ba6908040598ca275c0efca"
+
 # Colors
 num_colors=$(tput colors 2>/dev/null)
 if test -n "$num_colors" && test "$num_colors" -ge 8; then
@@ -465,21 +468,28 @@ ask_clean_install() {
   fi
 
   if [ -f "$SUPERVISOR_YML_PATH" ]; then
-    command printf "${indent}An installation already exists. Would you like to do a clean install? $(prompt n)"
-    read -r clean_install_response
-    clean_install_response=$(echo "$clean_install_response" | tr '[:upper:]' '[:lower:]')
-    case $clean_install_response in
-    y | yes)
-      increase_indent
-      success "Doing clean install!"
-      decrease_indent
+    # Check for default config file hash
+    cfg_file_hash=$(sha256sum "$SUPERVISOR_YML_PATH" | awk '{print $1}')
+    if [ "$cfg_file_hash" == "$DEFAULT_SUPERVISOR_CFG_HASH"]; then
+      # config matches default config, mark clean_install as true
       clean_install="true"
-      ;;
-    *)
-      warn "Doing upgrade instead of clean install"
-      clean_install="false"
-      ;;
-    esac
+    else
+      command printf "${indent}An installation already exists. Would you like to do a clean install? $(prompt n)"
+      read -r clean_install_response
+      clean_install_response=$(echo "$clean_install_response" | tr '[:upper:]' '[:lower:]')
+      case $clean_install_response in
+      y | yes)
+        increase_indent
+        success "Doing clean install!"
+        decrease_indent
+        clean_install="true"
+        ;;
+      *)
+        warn "Doing upgrade instead of clean install"
+        clean_install="false"
+        ;;
+      esac
+    fi
   else
     warn "Previous supervisor config not found, doing clean install"
     clean_install="true"

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -592,7 +592,7 @@ create_supervisor_config() {
   info "Creating supervisor config..."
 
   if [ -z "$OPAMP_ENDPOINT" ]; then
-    OPAMP_ENDPOINT="ws://localhost:3000/v1/opamp"
+    OPAMP_ENDPOINT="ws://localhost:3001/v1/opamp"
     increase_indent
     info "No OpAMP endpoint specified, starting agent using 'ws://localhost:3001/v1/opamp' as endpoint."
     decrease_indent

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -470,7 +470,7 @@ ask_clean_install() {
   if [ -f "$SUPERVISOR_YML_PATH" ]; then
     # Check for default config file hash
     cfg_file_hash=$(sha256sum "$SUPERVISOR_YML_PATH" | awk '{print $1}')
-    if [ "$cfg_file_hash" == "$DEFAULT_SUPERVISOR_CFG_HASH"]; then
+    if [ "$cfg_file_hash" = "$DEFAULT_SUPERVISOR_CFG_HASH" ]; then
       # config matches default config, mark clean_install as true
       clean_install="true"
     else

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -549,10 +549,7 @@ install_package() {
   decrease_indent
   succeeded
 
-  # If an endpoint was specified, we need to write the supervisor.yaml
-  if [ -n "$OPAMP_ENDPOINT" ]; then
-    create_supervisor_config "$SUPERVISOR_YML_PATH"
-  fi
+  create_supervisor_config "$SUPERVISOR_YML_PATH"
 
   # Install jmx jar
   info "Moving opentelemetry-java-contrib-jmx-metrics.jar to /opt..."
@@ -593,6 +590,13 @@ create_supervisor_config() {
   fi
 
   info "Creating supervisor config..."
+
+  if [ -z "$OPAMP_ENDPOINT" ]; then
+    OPAMP_ENDPOINT="ws://localhost:3000/v1/opamp"
+    increase_indent
+    info "No OpAMP endpoint specified, starting agent using 'ws://localhost:3001/v1/opamp' as endpoint."
+    decrease_indent
+  fi
 
   # Note here: We create the file and change permissions of the file here BEFORE writing info to it.
   # We do this because the file contains the secret key.

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -476,7 +476,7 @@ ask_clean_install() {
   if [ -f "$SUPERVISOR_YML_PATH" ]; then
     # Check for default config file hash
     cfg_file_hash=$(sha256sum "$SUPERVISOR_YML_PATH" | awk '{print $1}')
-    if [ "$cfg_file_hash" == "$DEFAULT_SUPERVISOR_CFG_HASH"]; then
+    if [ "$cfg_file_hash" = "$DEFAULT_SUPERVISOR_CFG_HASH" ]; then
       # config matches default config, mark clean_install as true
       clean_install="true"
     else

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -35,6 +35,9 @@ SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
 
+# Default Supervisor Config Hash
+DEFAULT_SUPERVISOR_CFG_HASH="ac4e6001f1b19d371bba6a2797ba0a55d7ca73151ba6908040598ca275c0efca"
+
 # out_file_path is the full path to the downloaded package (e.g. "/tmp/observiq-otel-collector_linux_amd64.deb")
 out_file_path="unknown"
 
@@ -471,21 +474,28 @@ ask_clean_install() {
   fi
 
   if [ -f "$SUPERVISOR_YML_PATH" ]; then
-    command printf "${indent}An installation already exists. Would you like to do a clean install? $(prompt n)"
-    read -r clean_install_response
-    clean_install_response=$(echo "$clean_install_response" | tr '[:upper:]' '[:lower:]')
-    case $clean_install_response in
-    y | yes)
-      increase_indent
-      success "Doing clean install!"
-      decrease_indent
+    # Check for default config file hash
+    cfg_file_hash=$(sha256sum "$SUPERVISOR_YML_PATH" | awk '{print $1}')
+    if [ "$cfg_file_hash" == "$DEFAULT_SUPERVISOR_CFG_HASH"]; then
+      # config matches default config, mark clean_install as true
       clean_install="true"
-      ;;
-    *)
-      warn "Doing upgrade instead of clean install"
-      clean_install="false"
-      ;;
-    esac
+    else
+      command printf "${indent}An installation already exists. Would you like to do a clean install? $(prompt n)"
+      read -r clean_install_response
+      clean_install_response=$(echo "$clean_install_response" | tr '[:upper:]' '[:lower:]')
+      case $clean_install_response in
+      y | yes)
+        increase_indent
+        success "Doing clean install!"
+        decrease_indent
+        clean_install="true"
+        ;;
+      *)
+        warn "Doing upgrade instead of clean install"
+        clean_install="false"
+        ;;
+      esac
+    fi
   else
     warn "Previous supervisor config not found, doing clean install"
     clean_install="true"

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -716,7 +716,7 @@ create_supervisor_config() {
   info "Creating supervisor config..."
 
   if [ -z "$OPAMP_ENDPOINT" ]; then
-    OPAMP_ENDPOINT="ws://localhost:3000/v1/opamp"
+    OPAMP_ENDPOINT="ws://localhost:3001/v1/opamp"
     increase_indent
     info "No OpAMP endpoint specified, starting agent using 'ws://localhost:3001/v1/opamp' as endpoint."
     decrease_indent

--- a/windows/install/generate-supervisor-yaml.bat
+++ b/windows/install/generate-supervisor-yaml.bat
@@ -12,13 +12,8 @@ echo %secret_key%
 echo %labels%
 
 if "%endpoint%"=="" (
-    echo Endpoint not specified; Not writing output yaml
-    exit /b 0
-)
-
-if "%secret_key%"=="" (
-    echo Secret Key not specified; Not writing output yaml
-    exit /b 0
+    echo Endpoint not specified, using default value of 'ws://localhost:3001/v1/opamp'
+    set "endpoint=ws://localhost:3001/v1/opamp"
 )
 
 set "supervisorFile=%install_dir%supervisor.yaml"

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -234,10 +234,10 @@
 
         <!-- Schedule the action that creates the supervisor.yaml file on initial install -->
         <Custom Action="CustomExecCreateSupervisorYaml_set" After="InstallInitialize" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         <Custom Action="CustomExecCreateSupervisorYaml" After="InstallFiles" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         
         <!-- Schedule the action that removes the supervisor.yaml file on final uninstall -->


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Want to be able to install and start supervisor without needing to provide an opamp endpoint or secret key. Neither are no longer required but since the supervisor needs an endpoint to actually start, use a default of `ws://localhost:3001/v1/opamp` when one isn't provided

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
