### PR TITLE
fix: Keep manager.yaml on uninstall

### DIFF
--- a/windows/install/generate-manager-yaml.bat
+++ b/windows/install/generate-manager-yaml.bat
@@ -5,11 +5,13 @@ set "install_dir=%~1"
 set "endpoint=%~2"
 set "secret_key=%~3"
 set "labels=%~4"
+set "clean=%~5"
 
 echo %install_dir%
 echo %endpoint%
 echo %secret_key%
 echo %labels%
+echo %clean%
 
 if "%endpoint%"=="" (
     echo Endpoint not specified; Not writing output yaml
@@ -17,6 +19,11 @@ if "%endpoint%"=="" (
 )
 
 set "managerfile=%install_dir%manager.yaml"
+
+if exist "%managerfile%" if "%clean%"=="" (
+    echo Manager.yaml already exists; Not writing output yaml
+    exit /b 0
+)
 
 echo Writing manager yaml
 set "endpointField=endpoint: "%endpoint%""

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -81,8 +81,8 @@
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
                 <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
-                        <Permission User="Administrators" GenericAll="yes" />
-                        <Permission User="Users" GenericAll="no" />
+                        <util:PermissionEx User="Administrators" GenericAll="yes" />
+                        <util:PermissionEx User="Users" GenericAll="no" />
                     </CreateFolder>
                 </Component>
                 {{define "FILES"}}

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -57,6 +57,13 @@
           <RegistrySearch Id='LOADINSTALLDIROLD' Type='raw'
             Root='HKLM' Key='Software\Microsoft\Windows\CurrentVersion\Uninstall\observIQ OpenTelemetry Collector' Name='InstallLocation' />
       </Property>
+
+      <Property Id="MANAGEREXISTS">
+          <DirectorySearch Id="CheckInstallDir" Path="INSTALLDIR" Depth="0">
+             <FileSearch Id="FindManager" Name="manager.yaml" />
+          </DirectorySearch>
+      </Property>
+
       
       <!-- Set default install dir to be "C:\Program Files\observIQ OpenTelemetry Collector" instead of "C:\Program Files\[ProductName]"-->
       <SetProperty Id="INSTALLDIR" Value="[$(var.Program_Files)]\observIQ OpenTelemetry Collector" Before="CostInitialize">
@@ -208,13 +215,6 @@
 
       <CustomAction Id="CustomExecCreateManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="check" />
 
-      <CustomAction Id="CustomExecRemoveManagerYaml_set"
-              Property="CustomExecRemoveManagerYaml"
-              Value="&quot;[CMDEXE]&quot; /C del &quot;[INSTALLDIR]manager.yaml&quot;"
-              Execute="immediate"/>
-
-      <CustomAction Id="CustomExecRemoveManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
-
       <InstallExecuteSequence>
          {{range $i, $h := .Hooks}}
          <Custom Action="CustomExec{{$i}}" {{if eq $h.When "install"}} After="InstallFiles" {{else if eq $h.Execute "immediate"}} Before="InstallValidate" {{else}} After="InstallInitialize" {{end}}>
@@ -234,12 +234,11 @@
 
         <!-- Schedule the action that creates the manager.yaml file on initial install -->
         <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED AND (not MANAGEREXISTS or CLEAN)]]>
         </Custom>
         <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED AND (not MANAGEREXISTS or CLEAN)]]>
         </Custom>
-    
       </InstallExecuteSequence>
 
       <Feature Id="DefaultFeature" Level="1">

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -63,12 +63,6 @@
         <![CDATA[NOT INSTALLDIR]]>
       </SetProperty>
 
-      <Property Id="MANAGEREXISTS">
-          <DirectorySearch Id="CheckInstallDir" Path="INSTALLDIR" Depth="0">
-             <FileSearch Id="FindManager" Name="manager.yaml" />
-          </DirectorySearch>
-      </Property>
-
       <!-- Set command prompt -->
       <SetProperty Id="CMDEXE" Value="[%SystemRoot]\system32\cmd.exe" Before="CostInitialize">
         <![CDATA[NOT CMDEXE]]>
@@ -78,12 +72,12 @@
 
         <Directory Id="$(var.Program_Files)">
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
-                <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
+                <!-- <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
                         <util:PermissionEx User="Administrators" GenericAll="yes" />
                         <util:PermissionEx User="Users" GenericAll="no" />
                     </CreateFolder>
-                </Component>
+                </Component> -->
                 {{define "FILES"}}
                 {{range $f := .}}
                 <Component 
@@ -209,7 +203,7 @@
 
       <CustomAction Id="CustomExecCreateManagerYaml_set"
               Property="CustomExecCreateManagerYaml"
-              Value="&quot;[CMDEXE]&quot; /C CALL &quot;[INSTALLDIR]install\generate-manager-yaml.bat&quot; &quot;[INSTALLDIR]&quot; &quot;[OPAMPENDPOINT]&quot; &quot;[OPAMPSECRETKEY]&quot; &quot;[OPAMPLABELS]&quot;"
+              Value="&quot;[CMDEXE]&quot; /C CALL &quot;[INSTALLDIR]install\generate-manager-yaml.bat&quot; &quot;[INSTALLDIR]&quot; &quot;[OPAMPENDPOINT]&quot; &quot;[OPAMPSECRETKEY]&quot; &quot;[OPAMPLABELS]&quot; &quot;[CLEAN]&quot;"
               Execute="immediate"/>
 
       <CustomAction Id="CustomExecCreateManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="check" />

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -239,14 +239,7 @@
         <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
             <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
-        
-        <!-- Schedule the action that removes the manager.yaml file on final uninstall -->
-        <Custom Action="CustomExecRemoveManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
-        </Custom>
-        <Custom Action="CustomExecRemoveManagerYaml" Before="RemoveFiles" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
-        </Custom>
+    
       </InstallExecuteSequence>
 
       <Feature Id="DefaultFeature" Level="1">

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -57,18 +57,17 @@
           <RegistrySearch Id='LOADINSTALLDIROLD' Type='raw'
             Root='HKLM' Key='Software\Microsoft\Windows\CurrentVersion\Uninstall\observIQ OpenTelemetry Collector' Name='InstallLocation' />
       </Property>
+      
+      <!-- Set default install dir to be "C:\Program Files\observIQ OpenTelemetry Collector" instead of "C:\Program Files\[ProductName]"-->
+      <SetProperty Id="INSTALLDIR" Value="[$(var.Program_Files)]\observIQ OpenTelemetry Collector" Before="CostInitialize">
+        <![CDATA[NOT INSTALLDIR]]>
+      </SetProperty>
 
       <Property Id="MANAGEREXISTS">
           <DirectorySearch Id="CheckInstallDir" Path="INSTALLDIR" Depth="0">
              <FileSearch Id="FindManager" Name="manager.yaml" />
           </DirectorySearch>
       </Property>
-
-      
-      <!-- Set default install dir to be "C:\Program Files\observIQ OpenTelemetry Collector" instead of "C:\Program Files\[ProductName]"-->
-      <SetProperty Id="INSTALLDIR" Value="[$(var.Program_Files)]\observIQ OpenTelemetry Collector" Before="CostInitialize">
-        <![CDATA[NOT INSTALLDIR]]>
-      </SetProperty>
 
       <!-- Set command prompt -->
       <SetProperty Id="CMDEXE" Value="[%SystemRoot]\system32\cmd.exe" Before="CostInitialize">

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -74,8 +74,8 @@
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
                 <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
-                        <util:PermissionEx User="Administrators" GenericAll="yes" />
-                        <util:PermissionEx User="Users" GenericAll="no" />
+                        <Permission User="Administrators" GenericAll="yes" />
+                        <Permission User="Users" GenericAll="no" />
                     </CreateFolder>
                 </Component>
                 {{define "FILES"}}

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -227,10 +227,10 @@
 
         <!-- Schedule the action that creates the manager.yaml file on initial install -->
         <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED AND (not MANAGEREXISTS or CLEAN)]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED AND (not MANAGEREXISTS or CLEAN)]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
       </InstallExecuteSequence>
 

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -72,12 +72,12 @@
 
         <Directory Id="$(var.Program_Files)">
             <Directory Id="INSTALLDIR" Name="observIQ OpenTelemetry Collector">
-                <!-- <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
+                <Component Id="ProductFolder" Guid="f8525e78-62c7-4665-81ad-f27e936edc88">
                     <CreateFolder>
                         <util:PermissionEx User="Administrators" GenericAll="yes" />
                         <util:PermissionEx User="Users" GenericAll="no" />
                     </CreateFolder>
-                </Component> -->
+                </Component>
                 {{define "FILES"}}
                 {{range $f := .}}
                 <Component 
@@ -259,7 +259,7 @@
          {{range $i, $e := .Shortcuts}}
          <ComponentRef Id="ApplicationShortcuts{{$i}}"/>
          {{end}}
-         <!-- <ComponentRef Id="ProductFolder"/> -->
+         <ComponentRef Id="ProductFolder"/>
       </Feature>
 
       <UI>

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -259,7 +259,7 @@
          {{range $i, $e := .Shortcuts}}
          <ComponentRef Id="ApplicationShortcuts{{$i}}"/>
          {{end}}
-         <ComponentRef Id="ProductFolder"/>
+         <!-- <ComponentRef Id="ProductFolder"/> -->
       </Feature>
 
       <UI>


### PR DESCRIPTION
### Proposed Change
For GPO rollouts of MSIs, the MSI is uninstalled, then the new MSI is installed. Because the manager.yaml should be persistent between this uninstall/install flow, we need to not remove it on uninstall.

Instead, like the linux scripts, we'll keep the manager.yaml between upgrades done this way. In addition, I've added a "CLEAN" property that can be specified via the command line that will allow you to cleanly install over the manager.yaml, even if it already exists.

Testing:
I've run these steps with the prebuilt MSI here: https://github.com/observIQ/bindplane-agent/actions/runs/11331967731
1. Install using above MSI, pointing it to a BPOP instance
2. Uninstall. Note the agent is disconnected in BPOP
3. Re-install using above MSI. Note that the agent reconnects, with the same ID.
4. Uninstall again. Note the agent is disconnected in BPOP.
5. Install, but this time specify `CLEAN="1"` at the end of the install command. 
6. Note a new agent connects to BPOP with a new agent ID.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
