### PR TITLE
fix: Fix panic when exporting tracing to GCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -495,7 +495,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.48.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.48.1 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.2 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ReneKroon/ttlcache/v2 v2.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -882,10 +882,10 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.48.1/go.mod h1:n8ee0TUmtsXm2GUWL86jkrxc8mPGRLuTJg13M/iW6Q0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.48.1 h1:u/of4NZ/0vK8c9Zjt6QLQtHjzjxKvplbrU8r1kLLYTk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.48.1/go.mod h1:nolt+2xPwKxTH0sQ5SKrK0kKEvVq12N/+3r6vhAmPvw=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.2 h1:B7ox5J7nwey9FPxobwU1wugDKgVqtFvwZRDS0YbM+tY=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.2/go.mod h1:VWMJ2cFLtnygvsntQ8JUNQ/VxoZiVd8ewsmyeKSK3k8=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.2 h1:ffI2ensdT33alWXmBDi/7cvCV7K3o7TF5oE44g8tiN0=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.2/go.mod h1:pNP/L2wDlaQnQlFvkDKGSruDoYRpmAxB6drgsskfYwg=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.1 h1:01bHLeqkrxYSkjvyTBEZ8rxBxDhWm1snWGEW73Te4lU=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.24.1/go.mod h1:UFO9jC3njhKdD/ymLnaKi7Or5miVWq06LvRWQNFfnTU=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.1 h1:oTX4vsorBZo/Zdum6OKPA4o7544hm6smoRv1QjpTwGo=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.48.1/go.mod h1:0wEl7vrAD8mehJyohS9HZy+WyEOaQO2mJx86Cvh93kM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.2 h1:th/AQTVtV5u0WVQln/ks+jxhkZ433MeOevmka55fkeg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.48.2/go.mod h1:wRbFgBQUVm1YXrvWKofAEmq9HNJTDphbAaJSSX01KUI=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=


### PR DESCRIPTION
### Proposed Change
There's a panic caused by us updating to v1.24.2 of the `github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace` package. A method was added to the interface, which this module uses, but the other module, which implements this interface, _embeds_ the interface. This means that the implementor always trivially implements the interface, even when it doesn't actually implement a method. When this unimplemented method is called, a nil panic happens because the embedded interface is always set to nil.

TL;DR v1.24.2 is incompatible with v0.111.0 of the GCP exporter, we need to use v1.24.1.


Here's a sample config I used to reproduce/test (this would panic immediately on startup):
```yaml
receivers:
  telemetrygeneratorreceiver:
    payloads_per_second: 1
    generators:
      - type: otlp
        additional_config:
          telemetry_type: "traces"
          otlp_json: '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"shopping-cart"}},{"key":"host.name","value":{"stringValue":"web-server-1"}},{"key":"duplicateKey","value":{"stringValue":"duplicateValueFromResource"}}]},"scopeSpans":[{"scope":{"name":"exampleTracer","version":"1.0"},"spans":[{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0102030405060708","name":"CheckoutProcess","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1646735053200000000","endTimeUnixNano":"1646735055200000000","attributes":[{"key":"http.method","value":{"stringValue":"GET"}},{"key":"duplicateKey","value":{"stringValue":"duplicateValueFromSpan"}},{"key":"user.id","value":{"intValue":12345}}],"status":{"code":"STATUS_CODE_OK"}}]}]}]}'

exporters:
  googlecloud/otel-agent-dev:
    credentials_file: "<redacted>"
    log:
      compression: gzip
      resource_filters:
        - regex: .*
    metric:
      compression: gzip
    project: "<redacted>"

service:
  pipelines:
    traces:
      receivers:
        - telemetrygeneratorreceiver
      exporters:
        - googlecloud/otel-agent-dev
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
