### PR TITLE
fix(Agent v2): Persist `supervisor_storage` on uninstall for windows

### DIFF
--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -215,13 +215,6 @@
 
       <CustomAction Id="CustomExecRemoveSupervisorYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
 
-      <CustomAction Id="CustomExecRemoveSupervisorStorage_set"
-            Property="CustomExecRemoveSupervisorStorage"
-            Value="&quot;[CMDEXE]&quot; \C del -r &quot;[INSTALLDIR]supervisor_storage&quot;"
-            Execute="immediate"/>
-
-      <CustomAction Id="CustomExecRemoveSupervisorStorage" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
-
       <InstallExecuteSequence>
          {{range $i, $h := .Hooks}}
          <Custom Action="CustomExec{{$i}}" {{if eq $h.When "install"}} After="InstallFiles" {{else if eq $h.Execute "immediate"}} Before="InstallValidate" {{else}} After="InstallInitialize" {{end}}>
@@ -252,14 +245,6 @@
             <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
         <Custom Action="CustomExecRemoveSupervisorYaml" Before="RemoveFiles" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
-        </Custom>
-
-        <!-- Schedule the action that removes the supervisor_storage dir on final uninstall -->
-        <Custom Action="CustomExecRemoveSupervisorStorage_set" After="InstallInitialize" >
-            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
-        </Custom>
-        <Custom Action="CustomExecRemoveSupervisorStorage" Before="RemoveFiles" >
             <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
       </InstallExecuteSequence>


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

When using the MSI to uninstall the agent it would hang while trying to remove the `supervisor_storage` dir. Instead we'll let this directory persist which will also solve a recent issue with v1 where agents reconnect as new agents after an update.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
