### PR TITLE
chore: Add OTEL_AES_CREDENTIAL_PROVIDER key to agent description

### DIFF
--- a/opamp/observiq/identity.go
+++ b/opamp/observiq/identity.go
@@ -15,6 +15,9 @@
 package observiq
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
 	"runtime"
 
 	ios "github.com/observiq/bindplane-agent/internal/os"
@@ -101,6 +104,14 @@ func (i *identity) ToAgentDescription() *protobufs.AgentDescription {
 		identifyingAttributes = append(identifyingAttributes, opamp.StringKeyValue("service.instance.name", *i.agentName))
 	} else {
 		identifyingAttributes = append(identifyingAttributes, opamp.StringKeyValue("service.instance.name", i.hostname))
+	}
+
+	key := os.Getenv("OTEL_AES_CREDENTIAL_PROVIDER")
+	if key != "" {
+		keyHash := ""
+		sha := sha256.Sum256([]byte(key))
+		keyHash = hex.EncodeToString(sha[0:4])
+		identifyingAttributes = append(identifyingAttributes, opamp.StringKeyValue("service.instance.key_hash", keyHash))
 	}
 
 	nonIdentifyingAttributes := []*protobufs.KeyValue{

--- a/opamp/observiq/identity.go
+++ b/opamp/observiq/identity.go
@@ -15,8 +15,6 @@
 package observiq
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"os"
 	"runtime"
 
@@ -106,14 +104,6 @@ func (i *identity) ToAgentDescription() *protobufs.AgentDescription {
 		identifyingAttributes = append(identifyingAttributes, opamp.StringKeyValue("service.instance.name", i.hostname))
 	}
 
-	key := os.Getenv("OTEL_AES_CREDENTIAL_PROVIDER")
-	if key != "" {
-		keyHash := ""
-		sha := sha256.Sum256([]byte(key))
-		keyHash = hex.EncodeToString(sha[0:4])
-		identifyingAttributes = append(identifyingAttributes, opamp.StringKeyValue("service.instance.key_hash", keyHash))
-	}
-
 	nonIdentifyingAttributes := []*protobufs.KeyValue{
 		opamp.StringKeyValue("os.arch", i.oSArch),
 		opamp.StringKeyValue("os.details", i.oSDetails),
@@ -124,6 +114,11 @@ func (i *identity) ToAgentDescription() *protobufs.AgentDescription {
 
 	if i.labels != nil {
 		nonIdentifyingAttributes = append(nonIdentifyingAttributes, opamp.StringKeyValue("service.labels", *i.labels))
+	}
+
+	key := os.Getenv("OTEL_AES_CREDENTIAL_PROVIDER")
+	if key != "" {
+		nonIdentifyingAttributes = append(nonIdentifyingAttributes, opamp.StringKeyValue("service.key", key))
 	}
 
 	agentDesc := &protobufs.AgentDescription{

--- a/opamp/observiq/identity_test.go
+++ b/opamp/observiq/identity_test.go
@@ -98,7 +98,6 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("service.name", "com.observiq.collector"),
 					opamp.StringKeyValue("service.version", "v1.2.3"),
 					opamp.StringKeyValue("service.instance.name", "my-linux-box"),
-					opamp.StringKeyValue("service.instance.key_hash", "62af8704"),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					opamp.StringKeyValue("os.arch", "amd64"),
@@ -106,6 +105,7 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("os.family", "linux"),
 					opamp.StringKeyValue("host.name", "my-linux-box"),
 					opamp.StringKeyValue("host.mac_address", "68-C7-B4-EB-A8-D2"),
+					opamp.StringKeyValue("service.key", "test-key"),
 				},
 			},
 		},
@@ -129,7 +129,6 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("service.name", "com.observiq.collector"),
 					opamp.StringKeyValue("service.version", "v1.2.3"),
 					opamp.StringKeyValue("service.instance.name", agentNameContents),
-					opamp.StringKeyValue("service.instance.key_hash", "62af8704"),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					opamp.StringKeyValue("os.arch", "amd64"),
@@ -138,6 +137,7 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("host.name", "my-linux-box"),
 					opamp.StringKeyValue("host.mac_address", "68-C7-B4-EB-A8-D2"),
 					opamp.StringKeyValue("service.labels", labelsContents),
+					opamp.StringKeyValue("service.key", "test-key"),
 				},
 			},
 		},

--- a/opamp/observiq/identity_test.go
+++ b/opamp/observiq/identity_test.go
@@ -15,6 +15,7 @@
 package observiq
 
 import (
+	"os"
 	"runtime"
 	"testing"
 
@@ -97,6 +98,7 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("service.name", "com.observiq.collector"),
 					opamp.StringKeyValue("service.version", "v1.2.3"),
 					opamp.StringKeyValue("service.instance.name", "my-linux-box"),
+					opamp.StringKeyValue("service.instance.key_hash", "62af8704"),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					opamp.StringKeyValue("os.arch", "amd64"),
@@ -127,6 +129,7 @@ func TestToAgentDescription(t *testing.T) {
 					opamp.StringKeyValue("service.name", "com.observiq.collector"),
 					opamp.StringKeyValue("service.version", "v1.2.3"),
 					opamp.StringKeyValue("service.instance.name", agentNameContents),
+					opamp.StringKeyValue("service.instance.key_hash", "62af8704"),
 				},
 				NonIdentifyingAttributes: []*protobufs.KeyValue{
 					opamp.StringKeyValue("os.arch", "amd64"),
@@ -141,6 +144,7 @@ func TestToAgentDescription(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		os.Setenv("OTEL_AES_CREDENTIAL_PROVIDER", "test-key")
 		t.Run(tc.desc, func(t *testing.T) {
 			actual := tc.ident.ToAgentDescription()
 			assert.Equal(t, tc.expected, actual)


### PR DESCRIPTION
### Proposed Change

Reports the encryption key stored in OTEL_AES_CREDENTIAL_PROVIDER env var to Bindplane.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
