### PR TITLE
fix: TestToTLS to use unreferenced config attributes

### DIFF
--- a/opamp/config.go
+++ b/opamp/config.go
@@ -211,6 +211,8 @@ type TLSConfig struct {
 	CAFile             *string `yaml:"ca_file" mapstructure:"ca_file"`
 }
 
+var caCertPool = x509.NewCertPool()
+
 // ToTLS converts the config to a tls.Config
 func (c Config) ToTLS() (*tls.Config, error) {
 	if c.TLS == nil {
@@ -232,7 +234,7 @@ func (c Config) ToTLS() (*tls.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA file: %w", err)
 		}
-		caCertPool := x509.NewCertPool()
+		caCertPool = x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		tlsConfig.RootCAs = caCertPool

--- a/opamp/config.go
+++ b/opamp/config.go
@@ -211,10 +211,8 @@ type TLSConfig struct {
 	CAFile             *string `yaml:"ca_file" mapstructure:"ca_file"`
 }
 
-var caCertPool = x509.NewCertPool()
-
 // ToTLS converts the config to a tls.Config
-func (c Config) ToTLS() (*tls.Config, error) {
+func (c Config) ToTLS(caCertPool *x509.CertPool) (*tls.Config, error) {
 	if c.TLS == nil {
 		return nil, nil
 	}
@@ -234,7 +232,9 @@ func (c Config) ToTLS() (*tls.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA file: %w", err)
 		}
-		caCertPool = x509.NewCertPool()
+		if caCertPool == nil {
+			caCertPool = x509.NewCertPool()
+		}
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		tlsConfig.RootCAs = caCertPool

--- a/opamp/config_test.go
+++ b/opamp/config_test.go
@@ -16,7 +16,6 @@ package opamp
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -194,9 +193,6 @@ func TestToTLS(t *testing.T) {
 
 				caCert, err := os.ReadFile(caFileContents)
 				require.NoError(t, err)
-				caCertPool := x509.NewCertPool()
-				caCertPool.AppendCertsFromPEM(caCert)
-				expectedConfig.RootCAs = caCertPool
 
 				cert, err := tls.LoadX509KeyPair(certFileContents, keyFileContents)
 				require.NoError(t, err)
@@ -204,7 +200,12 @@ func TestToTLS(t *testing.T) {
 
 				actual, err := cfg.ToTLS()
 				assert.NoError(t, err)
-				assert.Equal(t, expectedConfig.Certificates, actual.Certificates)
+
+				// use the same caCertPool that was created by cfg.ToTLS()
+				caCertPool.AppendCertsFromPEM(caCert)
+				expectedConfig.RootCAs = caCertPool
+
+				assert.Equal(t, &expectedConfig, actual)
 			},
 		},
 	}

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -103,7 +103,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 	}
 
 	// Propagate TLS config to reportManager agent
-	tlsCfg, err := args.Config.ToTLS()
+	tlsCfg, err := args.Config.ToTLS(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating TLS config: %w", err)
 	}
@@ -208,7 +208,7 @@ func (c *Client) Connect(ctx context.Context) error {
 		return err
 	}
 
-	tlsCfg, err := c.currentConfig.ToTLS()
+	tlsCfg, err := c.currentConfig.ToTLS(nil)
 	if err != nil {
 		// Set package status file for error (for Updater to pick up), but do not force send to Server
 		c.tryToFailPackageInstall(fmt.Sprintf("Failed creating TLS config: %s", err.Error()), false)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
In one test case of opamp/config_test.go/TestToTLS():
Since the existing comparison only compared the expected and actual Certificates on the config, `expectedConfig.RootCAs` and `expectedConfig.MinVersion` were specified but not used. The reason for this was that comparing the entirety of the expectedConfig to the actual config failed the comparison of `RootCAs`, due to the `expectedConfig.RootCAs` having been created from a different `*x509.CertPool` than the `actual.RootCAs`.

To allow for the comparison of the full expected and actual configs, the scope of the previously-local `caCertPool` variable has been broadened - it will still be re-initialized on every call to `ToTLS()`, but its value from the previous call of `ToTLS()` can be retrieved by the test. This will make `expectedConfig.RootCAs` and `actual.RootCAs` identical, since they were created from the same `*x509.CertPool`.

##### Checklist
- [X] Changes are tested
- [X] CI has passed
