### PR TITLE
fix: snapshot reporting use HTTP_PROXY and HTTPS_PROXY env vars

### DIFF
--- a/internal/report/agent_client_test.go
+++ b/internal/report/agent_client_test.go
@@ -34,6 +34,9 @@ func TestNewAgentClient(t *testing.T) {
 	require.NotNil(t, client.client)
 }
 
+// TestAgentClientDo tests the AgentClient Do method
+// Note: this unit test can't test the proxy settings since the test server has a loopback address
+// (127.*.*.* or localhost) and the proxy settings are ignored for these addresses.
 func TestAgentClientDo(t *testing.T) {
 	secretKey := "secret_key"
 	testCases := []struct {


### PR DESCRIPTION
### Proposed Change

The AgentClient wrapper around http.Client (used to add headers to snapshot reports) didn't include a proxy setting in its Transport, so snapshots failed in environments configured with a proxy and without DNS access, specifically for Windows.

### Testing

We have a proxy configured on the localnet at bp-qa-ub-proxy.bluemedora.localnet:9094

See https://observiq.com/docs/advanced-setup/configuration/proxy for setting up an agent with a proxy. The current agent will create an error when the snapshot console is opened in BP, with this PR snapshot should appear normally.

For Windows:

Using regedit, add to the `Environment` key for `observiq-otel-collector`
```
HTTP_PROXY=http://bp-qa-ub-proxy.bluemedora.localnet:9094
HTTPS_PROXYhttp://bp-qa-ub-proxy.bluemedora.localnet:9094
```
<img width="693" alt="image" src="https://github.com/user-attachments/assets/a57515b8-27e9-4549-919c-d566ec4833b8">

Restart the collector using `Services`.

For macOS agent:


Add `HTTP_PROXY` and `HTTPS_PROXY` to the `EnvironmentVariables` dict in the launchd service file `/Library/LaunchDaemons/com.observiq.collector.plist` (other values are shown for context):

```xml
<key>EnvironmentVariables</key>
<dict>
    <key>HTTP_PROXY</key>
    <string>http://bp-qa-ub-proxy.bluemedora.localnet:9094</string>    
    <key>HTTPS_PROXY</key>
    <string>http://bp-qa-ub-proxy.bluemedora.localnet:9094</string>    
    <key>OIQ_OTEL_COLLECTOR_HOME</key>
    <string>/opt/observiq-otel-collector/</string>
    <key>OIQ_OTEL_COLLECTOR_STORAGE</key>
    <string>/opt/observiq-otel-collector/storage</string>
</dict>
```

Then restart the agent:

```bash
sudo launchctl unload /Library/LaunchDaemons/com.observiq.collector.plist
sudo launchctl load /Library/LaunchDaemons/com.observiq.collector.plist
```


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
