### PR TITLE
deps: Bump min Go version to 1.22.7

### DIFF
--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/plugindocgen
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/receiver/pluginreceiver v1.64.0

--- a/counter/go.mod
+++ b/counter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/counter
 
-go 1.22.6
+go 1.22.7
 
 require github.com/stretchr/testify v1.9.0
 

--- a/exporter/azureblobexporter/go.mod
+++ b/exporter/azureblobexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/exporter/azureblobexporter
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1

--- a/exporter/chronicleexporter/go.mod
+++ b/exporter/chronicleexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/exporter/chronicleexporter
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/golang/mock v1.6.0

--- a/exporter/chronicleforwarderexporter/go.mod
+++ b/exporter/chronicleforwarderexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/exporter/chronicleforwarderexporter
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/expr v1.64.0

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -2,8 +2,6 @@ module github.com/observiq/bindplane-agent/exporter/googlecloudexporter
 
 go 1.22.7
 
-toolchain go1.23.1
-
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.49.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.113.0

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -2,8 +2,6 @@ module github.com/observiq/bindplane-agent/exporter/googlemanagedprometheusexpor
 
 go 1.22.7
 
-toolchain go1.23.1
-
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.113.0
 	github.com/stretchr/testify v1.9.0

--- a/exporter/qradar/go.mod
+++ b/exporter/qradar/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/exporter/qradar
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/expr v1.64.0

--- a/exporter/snowflakeexporter/go.mod
+++ b/exporter/snowflakeexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/exporter/snowflakeexporter
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/expr/go.mod
+++ b/expr/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/expr
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.113.0

--- a/extension/bindplaneextension/go.mod
+++ b/extension/bindplaneextension/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/extension/bindplaneextension
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/golang/snappy v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/observiq/bindplane-agent
 
 go 1.22.7
 
-toolchain go1.23.1
-
 require (
 	github.com/google/uuid v1.6.0
 	github.com/observiq/bindplane-agent/exporter/azureblobexporter v1.64.0

--- a/internal/measurements/go.mod
+++ b/internal/measurements/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/internal/measurements
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0

--- a/internal/rehydration/go.mod
+++ b/internal/rehydration/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/internal/rehydration
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/internal/testutils v1.64.0

--- a/internal/report/go.mod
+++ b/internal/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/internal/report
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0

--- a/internal/testutils/go.mod
+++ b/internal/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/internal/testutils
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/packagestate/go.mod
+++ b/packagestate/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/packagestate
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opamp-go v0.9.0

--- a/processor/datapointcountprocessor/go.mod
+++ b/processor/datapointcountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/datapointcountprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/counter v1.64.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/logcountprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/counter v1.64.0

--- a/processor/lookupprocessor/go.mod
+++ b/processor/lookupprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/lookupprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/processor/maskprocessor/go.mod
+++ b/processor/maskprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/maskprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/metricextractprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/expr v1.64.0

--- a/processor/metricstatsprocessor/go.mod
+++ b/processor/metricstatsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/metricstatsprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.113.0

--- a/processor/removeemptyvaluesprocessor/go.mod
+++ b/processor/removeemptyvaluesprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/removeemptyvaluesprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/processor/resourceattributetransposerprocessor/go.mod
+++ b/processor/resourceattributetransposerprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/resourceattributetransposerprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/samplingprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/expr v1.64.0

--- a/processor/snapshotprocessor/go.mod
+++ b/processor/snapshotprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/snapshotprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/internal/report v1.64.0

--- a/processor/spancountprocessor/go.mod
+++ b/processor/spancountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/spancountprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/counter v1.64.0

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/processor/throughputmeasurementprocessor
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/observiq/bindplane-agent/internal/measurements v1.64.0

--- a/receiver/awss3rehydrationreceiver/go.mod
+++ b/receiver/awss3rehydrationreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/awss3rehydrationreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1

--- a/receiver/azureblobrehydrationreceiver/go.mod
+++ b/receiver/azureblobrehydrationreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/azureblobrehydrationreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.1

--- a/receiver/httpreceiver/go.mod
+++ b/receiver/httpreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/httpreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.113.0

--- a/receiver/m365receiver/go.mod
+++ b/receiver/m365receiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/m365receiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/receiver/oktareceiver/go.mod
+++ b/receiver/oktareceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/oktareceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/okta/okta-sdk-golang/v2 v2.20.0

--- a/receiver/pluginreceiver/go.mod
+++ b/receiver/pluginreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/pluginreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c

--- a/receiver/routereceiver/go.mod
+++ b/receiver/routereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/routereceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/receiver/sapnetweaverreceiver/go.mod
+++ b/receiver/sapnetweaverreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/sapnetweaverreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/receiver/telemetrygeneratorreceiver/go.mod
+++ b/receiver/telemetrygeneratorreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/receiver/telemetrygeneratorreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.113.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/bindplane-agent/updater
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Bumps the minimum go version to 1.22.7

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
