### PR TITLE
[exporter/chronicleexporter]: Optimize getRawField when field is "body"

### DIFF
--- a/exporter/chronicleexporter/marshal.go
+++ b/exporter/chronicleexporter/marshal.go
@@ -269,22 +269,25 @@ func (m *protoMarshaler) getRawField(ctx context.Context, field string, logRecor
 	case logTypeField:
 		attributes := logRecord.Attributes().AsRaw()
 		if logType, ok := attributes["log_type"]; ok {
-			// TODO(jsirianni): Check type before asserting
-			return logType.(string), nil
+			if v, ok := logType.(string); ok {
+				return v, nil
+			}
 		}
 		return "", nil
 	case chronicleLogTypeField:
 		attributes := logRecord.Attributes().AsRaw()
 		if logType, ok := attributes["chronicle_log_type"]; ok {
-			// TODO(jsirianni): Check type before asserting
-			return logType.(string), nil
+			if v, ok := logType.(string); ok {
+				return v, nil
+			}
 		}
 		return "", nil
 	case chronicleNamespaceField:
 		attributes := logRecord.Attributes().AsRaw()
 		if namespace, ok := attributes["chronicle_namespace"]; ok {
-			// TODO(jsirianni): Check type before asserting
-			return namespace.(string), nil
+			if v, ok := namespace.(string); ok {
+				return v, nil
+			}
 		}
 		return "", nil
 	}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

getRawField is called three times for every log record. One of those times is for reading the "field to send" value. Generally, "field to send" will be `body`. Body can be either a string or a map. 

If `field` is body, we can read the underlying string or map and return it. No need to use an expensive OTTL expression.

Before

```
Benchmark_getRawField/String_body-32         	  522542	     21758 ns/op
Benchmark_getRawField/Empty_body-32          	  566030	     23555 ns/op
Benchmark_getRawField/Map_body-32            	  529818	     26545 ns/op
Benchmark_getRawField/Map_body_field-32      	  427791	     29865 ns/op
Benchmark_getRawField/Map_body_field_missing-32         	  477262	     26456 ns/op
Benchmark_getRawField/String_attribute-32               	  480273	     25780 ns/op
Benchmark_getRawField/String_attribute_missing-32       	  477435	     25497 ns/op
```

After

```
Benchmark_getRawField/String_body-32         	337642196	         3.273 ns/op
Benchmark_getRawField/Empty_body-32          	416621745	         2.768 ns/op
Benchmark_getRawField/Map_body-32            	 1249923	       947.6 ns/op
Benchmark_getRawField/Map_body_field-32      	   35430	     32555 ns/op
Benchmark_getRawField/Map_body_field_missing-32         	   38889	     34986 ns/op
Benchmark_getRawField/Attribute_log_type-32             	 5498604	       233.0 ns/op
Benchmark_getRawField/Attribute_log_type_missing-32     	 7433708	       164.2 ns/op
Benchmark_getRawField/Attribute_chronicle_log_type-32   	 7790766	       218.1 ns/op
Benchmark_getRawField/Attribute_chronicle_namespace-32  	 4046871	       284.6 ns/op
```

Benchmarks for string body and map body have almost no costs now.

The tests introduced in https://github.com/observIQ/bindplane-agent/pull/1966 should prove that the output is the same.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
