### PR TITLE
feat: SSAPI pass timestamps in Splunk query (BPS-283)

### DIFF
--- a/receiver/splunksearchapireceiver/client.go
+++ b/receiver/splunksearchapireceiver/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
@@ -59,7 +60,7 @@ func newSplunkSearchAPIClient(ctx context.Context, settings component.TelemetryS
 func (c defaultSplunkSearchAPIClient) CreateSearchJob(search string) (CreateJobResponse, error) {
 	endpoint := fmt.Sprintf("%s/services/search/jobs", c.endpoint)
 
-	reqBody := fmt.Sprintf(`search=%s`, search)
+	reqBody := fmt.Sprintf(`search=%s`, url.QueryEscape(search))
 	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer([]byte(reqBody)))
 	if err != nil {
 		return CreateJobResponse{}, err

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -72,6 +72,10 @@ func (cfg *Config) Validate() error {
 			return errNonStandaloneSearchQuery
 		}
 
+		if strings.Contains(search.Query, "earliest=") || strings.Contains(search.Query, "latest=") {
+			return errors.New("time query parameters must be configured using only the 'earliest_time' and 'latest_time' configuration parameters")
+		}
+
 		if search.EarliestTime == "" {
 			return errors.New("missing earliest_time in search")
 		}

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -72,7 +72,12 @@ func (cfg *Config) Validate() error {
 			return errNonStandaloneSearchQuery
 		}
 
-		if strings.Contains(search.Query, "earliest=") || strings.Contains(search.Query, "latest=") {
+		// ensure user query does not include time parameters
+		if strings.Contains(search.Query, "earliest=") ||
+			strings.Contains(search.Query, "latest=") ||
+			strings.Contains(search.Query, "starttime=") ||
+			strings.Contains(search.Query, "endtime=") ||
+			strings.Contains(search.Query, "timeformat=") {
 			return errors.New("time query parameters must be configured using only the 'earliest_time' and 'latest_time' configuration parameters")
 		}
 

--- a/receiver/splunksearchapireceiver/config.go
+++ b/receiver/splunksearchapireceiver/config.go
@@ -63,7 +63,7 @@ func (cfg *Config) Validate() error {
 			return errors.New("missing query in search")
 		}
 
-		// query implicitly starts with "search" command
+		// query must start with "search" command
 		if !strings.HasPrefix(search.Query, "search ") {
 			return errNonStandaloneSearchQuery
 		}

--- a/receiver/splunksearchapireceiver/config_test.go
+++ b/receiver/splunksearchapireceiver/config_test.go
@@ -215,6 +215,21 @@ func TestValidate(t *testing.T) {
 			},
 			errExpected: false,
 		},
+		{
+			desc:     "Query with ealiest and latest time",
+			endpoint: "http://localhost:8089",
+			username: "user",
+			password: "password",
+			searches: []Search{
+				{
+					Query:        "search index=_internal earliest=2024-10-30T04:00:00.000Z latest=2024-10-30T14:00:00.000Z",
+					EarliestTime: "2024-10-30T04:00:00.000Z",
+					LatestTime:   "2024-10-30T14:00:00.000Z",
+				},
+			},
+			errExpected: true,
+			errText:     "time query parameters must be configured using only the 'earliest_time' and 'latest_time' configuration parameters",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/receiver/splunksearchapireceiver/factory.go
+++ b/receiver/splunksearchapireceiver/factory.go
@@ -31,7 +31,7 @@ var (
 func createDefaultConfig() component.Config {
 	return &Config{
 		ClientConfig:    confighttp.NewDefaultClientConfig(),
-		JobPollInterval: 10 * time.Second,
+		JobPollInterval: 5 * time.Second,
 	}
 }
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Instead of passing the query from the config as-is, use the earliest and latest time config fields to specify a `starttime` and `endtime` on the created query. This will eliminate unnecessary API calls and remove a lot of the post-processing done by the receiver.

Example output:
```
{"level":"info","ts":"2024-11-14T14:34:26.854-0500","caller":"splunksearchapireceiver/receiver.go:155","msg":"creating search","kind":"receiver","name":"splunksearchapi","data_type":"logs","query":"search index=otel starttime=\"2024-11-14T00:00:00.000Z\" endtime=\"2024-11-14T20:00:00.000Z\" timeformat=\"%Y-%m-%dT%H:%M:%S\""}
{"level":"info","ts":"2024-11-14T14:34:32.094-0500","caller":"splunksearchapireceiver/receiver.go:142","msg":"search completed","kind":"receiver","name":"splunksearchapi","data_type":"logs"}
{"level":"info","ts":"2024-11-14T14:34:32.094-0500","caller":"splunksearchapireceiver/receiver.go:67","msg":"fetching search results","kind":"receiver","name":"splunksearchapi","data_type":"logs"}
{"level":"info","ts":"2024-11-14T14:34:32.144-0500","caller":"splunksearchapireceiver/receiver.go:72","msg":"search results fetched","kind":"receiver","name":"splunksearchapi","data_type":"logs","num_results":20}
```
<img width="1377" alt="Screenshot 2024-11-14 at 3 06 52 PM" src="https://github.com/user-attachments/assets/dfbb6ac4-a78f-4488-a4bb-67368f10a666">

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
