### PR TITLE
fix: Add `-r` flag back to unix install script

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -937,6 +937,10 @@ main() {
         base_url=$2
         shift 2
         ;;
+      -r | --uninstall)
+        uninstall
+        exit 0
+        ;;
       -h | --help)
         usage
         exit 0


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Flag got accidentally removed during rebase so adding it back in. Verified -r is present in macos script. Probably trigger another release afterwards.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
