### PR TITLE
chore: Add uninstall usage blurb to install_unix.sh

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -183,6 +183,9 @@ Usage:
       set to configure the agent version.
       Example: '-v 1.2.12' will download 1.2.12.
 
+  $(fg_yellow '-r, --uninstall')
+      Stops the agent services and uninstalls the agent.
+
   $(fg_yellow '-l, --url')
       Defines the URL that the components will be downloaded from.
       If not provided, this will default to BindPlane Agent\'s GitHub releases.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Follow up pr to #1970. Noticed this install script lacks a usage blurb for the uninstall cmd. Copied same blurb over from macos script.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
