### PR TITLE
fix(dev): Name of binary for `make kill`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ run-supervisor:
 .PHONY: kill
 kill:
 	pkill -9 opampsupervisor || true
-	pkill -9 observiq-agent-distro || true
+	pkill -9 collector_$(GOOS)_$(GOARCH) || true
 
 # Stops processes and cleans up
 .PHONY: reset


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change

Update name of default collector binary for `make kill`

```bash
$ make kill
pkill -9 opampsupervisor || true
pkill -9 collector_darwin_arm64 || true
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
