### PR TITLE
fix: Set CURR_VERSION for new v2 release-prep calls

### DIFF
--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Release Prep
-        run: make release-prep
+        run: make release-prep CURR_VERSION=${{ github.ref_name }}
       - name: Build Binaries
         run: make build-binaries
       - name: Copy Windows Collector Binary

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install tools
         run: make install-tools
       - name: Release Prep
-        run: make release-prep CURR_VERSION=${{ github.ref_name }}
+        run: make release-prep CURR_VERSION=${{ github.event.inputs.version }}
       - name: Build Binaries
         run: make build-binaries
       - name: Copy Windows Collector Binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         run: make install-tools
       # Needed until supervisor binary is released
       - name: Build Supervisor Binary
-        run: make release-prep
+        run: make release-prep CURR_VERSION=${{ github.ref_name }}
       - name: Build Windows Binaries
         run: make build-binaries
       - name: Copy Windows Collector Binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@ project_name: observiq-otel-collector
 
 before:
   hooks:
-    - make release-prep CURR_VERSION={{ .Version }}
+    - make release-prep CURR_VERSION=v{{ .Version }}
     - make build-all OUTDIR="tmp"
 
 after:

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ update-modules:
 release-prep:
 	@rm -rf release_deps
 	@mkdir release_deps
-	@echo 'v$(CURR_VERSION)' > release_deps/VERSION.txt
+	@echo '$(CURR_VERSION)' > release_deps/VERSION.txt
 	bash ./buildscripts/download-dependencies.sh release_deps
 	@cp -r ./plugins release_deps/
 	@cp service/com.observiq.collector.plist release_deps/com.observiq.collector.plist


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
Set CURR_VERSION flag so that `make release-prep` provides the correct version in VERSION.txt.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
