### PR TITLE
fix: Shut down zombie goroutine in chronicleexporter

### DIFF
--- a/exporter/chronicleexporter/exporter.go
+++ b/exporter/chronicleexporter/exporter.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/observiq/bindplane-agent/exporter/chronicleexporter/protos/api"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
@@ -54,31 +55,21 @@ const (
 type chronicleExporter struct {
 	cfg                     *Config
 	logger                  *zap.Logger
-	client                  api.IngestionServiceV2Client
-	conn                    *grpc.ClientConn
 	marshaler               logMarshaler
-	metrics                 *exporterMetrics
 	collectorID, exporterID string
-	wg                      sync.WaitGroup
 
-	cancel context.CancelFunc
+	// fields used for gRPC
+	grpcClient api.IngestionServiceV2Client
+	grpcConn   *grpc.ClientConn
+	wg         sync.WaitGroup
+	cancel     context.CancelFunc
+	metrics    *exporterMetrics
 
+	// fields used for HTTP
 	httpClient *http.Client
 }
 
 func newExporter(cfg *Config, params exporter.Settings, collectorID, exporterID string) (*chronicleExporter, error) {
-	creds, err := loadGoogleCredentials(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("load Google credentials: %w", err)
-	}
-
-	ts := creds.TokenSource
-	opts := []grpc.DialOption{
-		// Apply OAuth tokens for each RPC call
-		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: ts}),
-		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
-	}
-
 	customerID, err := uuid.Parse(cfg.CustomerID)
 	if err != nil {
 		return nil, fmt.Errorf("parse customer ID: %w", err)
@@ -94,39 +85,77 @@ func newExporter(cfg *Config, params exporter.Settings, collectorID, exporterID 
 		return nil, fmt.Errorf("parse collector ID: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	exp := &chronicleExporter{
+	return &chronicleExporter{
 		cfg:         cfg,
 		logger:      params.Logger,
 		metrics:     newExporterMetrics(uuidCID[:], customerID[:], exporterID, cfg.Namespace),
 		marshaler:   marshaller,
 		collectorID: collectorID,
 		exporterID:  exporterID,
-		cancel:      cancel,
+	}, nil
+}
+
+func (ce *chronicleExporter) Start(_ context.Context, host component.Host) error {
+	creds, err := loadGoogleCredentials(ce.cfg)
+	if err != nil {
+		return fmt.Errorf("load Google credentials: %w", err)
 	}
 
-	if cfg.Protocol == protocolHTTPS {
-		exp.httpClient = oauth2.NewClient(context.Background(), creds.TokenSource)
-	} else {
-		conn, err := grpc.NewClient(cfg.Endpoint+":443", opts...)
-		if err != nil {
-			return nil, fmt.Errorf("dial: %w", err)
-		}
-
-		exp.conn = conn
-		exp.client = api.NewIngestionServiceV2Client(conn)
-
-		if cfg.CollectAgentMetrics {
-			exp.wg.Add(1)
-			go exp.startHostMetricsCollection(ctx)
-		}
+	if ce.cfg.Protocol == protocolHTTPS {
+		ce.httpClient = oauth2.NewClient(context.Background(), creds.TokenSource)
+		return nil
 	}
 
-	return exp, nil
+	ctx, cancel := context.WithCancel(context.Background())
+	ce.cancel = cancel
+
+	opts := []grpc.DialOption{
+		// Apply OAuth tokens for each RPC call
+		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: creds.TokenSource}),
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
+	}
+	conn, err := grpc.NewClient(ce.cfg.Endpoint+":443", opts...)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	ce.grpcConn = conn
+	ce.grpcClient = api.NewIngestionServiceV2Client(conn)
+
+	if ce.cfg.CollectAgentMetrics {
+		ce.wg.Add(1)
+		go ce.startHostMetricsCollection(ctx)
+	}
+
+	return nil
+}
+
+func (ce *chronicleExporter) Shutdown(context.Context) error {
+	if ce.cfg.Protocol == protocolHTTPS {
+		t := ce.httpClient.Transport.(*oauth2.Transport)
+		if t.Base != nil {
+			t.Base.(*http.Transport).CloseIdleConnections()
+		} else {
+			http.DefaultTransport.(*http.Transport).CloseIdleConnections()
+		}
+		return nil
+	}
+	if ce.cancel != nil {
+		ce.cancel()
+		ce.wg.Wait()
+	}
+	if ce.grpcConn != nil {
+		if err := ce.grpcConn.Close(); err != nil {
+			return fmt.Errorf("connection close: %s", err)
+		}
+	}
+	return nil
+}
+
+func (ce *chronicleExporter) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func loadGoogleCredentials(cfg *Config) (*google.Credentials, error) {
-
 	scope := grpcScope
 	if cfg.Protocol == protocolHTTPS {
 		scope = httpScope
@@ -151,10 +180,6 @@ func loadGoogleCredentials(cfg *Config) (*google.Credentials, error) {
 	}
 }
 
-func (ce *chronicleExporter) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
-}
-
 func (ce *chronicleExporter) logsDataPusher(ctx context.Context, ld plog.Logs) error {
 	payloads, err := ce.marshaler.MarshalRawLogs(ctx, ld)
 	if err != nil {
@@ -173,7 +198,7 @@ func (ce *chronicleExporter) logsDataPusher(ctx context.Context, ld plog.Logs) e
 func (ce *chronicleExporter) uploadToChronicle(ctx context.Context, request *api.BatchCreateLogsRequest) error {
 	totalLogs := int64(len(request.GetBatch().GetEntries()))
 
-	_, err := ce.client.BatchCreateLogs(ctx, request, ce.buildOptions()...)
+	_, err := ce.grpcClient.BatchCreateLogs(ctx, request, ce.buildOptions()...)
 	if err != nil {
 		errCode := status.Code(err)
 		switch errCode {
@@ -221,23 +246,12 @@ func (ce *chronicleExporter) startHostMetricsCollection(ctx context.Context) {
 				ce.logger.Error("Failed to collect host metrics", zap.Error(err))
 			}
 			request := ce.metrics.getAndReset()
-			_, err = ce.client.BatchCreateEvents(ctx, request, ce.buildOptions()...)
+			_, err = ce.grpcClient.BatchCreateEvents(ctx, request, ce.buildOptions()...)
 			if err != nil {
 				ce.logger.Error("Failed to upload host metrics", zap.Error(err))
 			}
 		}
 	}
-}
-
-func (ce *chronicleExporter) Shutdown(context.Context) error {
-	ce.cancel()
-	ce.wg.Wait()
-	if ce.conn != nil {
-		if err := ce.conn.Close(); err != nil {
-			return fmt.Errorf("connection close: %s", err)
-		}
-	}
-	return nil
 }
 
 func (ce *chronicleExporter) logsHTTPDataPusher(ctx context.Context, ld plog.Logs) error {

--- a/exporter/chronicleexporter/exporter_test.go
+++ b/exporter/chronicleexporter/exporter_test.go
@@ -50,11 +50,11 @@ func TestLogsDataPusher(t *testing.T) {
 				marshaller := NewMockMarshaler(t)
 				marshaller.On("MarshalRawLogs", mock.Anything, mock.Anything).Return([]*api.BatchCreateLogsRequest{{}}, nil)
 				return &chronicleExporter{
-					cfg:       &cfg,
-					metrics:   newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
-					logger:    zap.NewNop(),
-					client:    mockClient,
-					marshaler: marshaller,
+					cfg:        &cfg,
+					metrics:    newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
+					logger:     zap.NewNop(),
+					grpcClient: mockClient,
+					marshaler:  marshaller,
 				}
 			},
 			setupMocks: func(mockClient *mocks.MockIngestionServiceV2Client) {
@@ -69,11 +69,11 @@ func TestLogsDataPusher(t *testing.T) {
 				marshaller := NewMockMarshaler(t)
 				marshaller.On("MarshalRawLogs", mock.Anything, mock.Anything).Return([]*api.BatchCreateLogsRequest{{}}, nil)
 				return &chronicleExporter{
-					cfg:       &cfg,
-					metrics:   newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
-					logger:    zap.NewNop(),
-					client:    mockClient,
-					marshaler: marshaller,
+					cfg:        &cfg,
+					metrics:    newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
+					logger:     zap.NewNop(),
+					grpcClient: mockClient,
+					marshaler:  marshaller,
 				}
 			},
 			setupMocks: func(mockClient *mocks.MockIngestionServiceV2Client) {
@@ -90,11 +90,11 @@ func TestLogsDataPusher(t *testing.T) {
 				marshaller := NewMockMarshaler(t)
 				marshaller.On("MarshalRawLogs", mock.Anything, mock.Anything).Return([]*api.BatchCreateLogsRequest{{}}, nil)
 				return &chronicleExporter{
-					cfg:       &cfg,
-					metrics:   newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
-					logger:    zap.NewNop(),
-					client:    mockClient,
-					marshaler: marshaller,
+					cfg:        &cfg,
+					metrics:    newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
+					logger:     zap.NewNop(),
+					grpcClient: mockClient,
+					marshaler:  marshaller,
 				}
 			},
 			setupMocks: func(mockClient *mocks.MockIngestionServiceV2Client) {
@@ -112,11 +112,11 @@ func TestLogsDataPusher(t *testing.T) {
 				// Simulate an error during log marshaling
 				marshaller.On("MarshalRawLogs", mock.Anything, mock.Anything).Return(nil, errors.New("marshal error"))
 				return &chronicleExporter{
-					cfg:       &cfg,
-					metrics:   newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
-					logger:    zap.NewNop(),
-					client:    mockClient,
-					marshaler: marshaller,
+					cfg:        &cfg,
+					metrics:    newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
+					logger:     zap.NewNop(),
+					grpcClient: mockClient,
+					marshaler:  marshaller,
 				}
 			},
 			setupMocks: func(_ *mocks.MockIngestionServiceV2Client) {
@@ -132,11 +132,11 @@ func TestLogsDataPusher(t *testing.T) {
 				// Return an empty slice to simulate no logs to push
 				marshaller.On("MarshalRawLogs", mock.Anything, mock.Anything).Return([]*api.BatchCreateLogsRequest{}, nil)
 				return &chronicleExporter{
-					cfg:       &cfg,
-					metrics:   newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
-					logger:    zap.NewNop(),
-					client:    mockClient,
-					marshaler: marshaller,
+					cfg:        &cfg,
+					metrics:    newExporterMetrics([]byte{}, []byte{}, "", cfg.Namespace),
+					logger:     zap.NewNop(),
+					grpcClient: mockClient,
+					marshaler:  marshaller,
 				}
 			},
 			setupMocks: func(_ *mocks.MockIngestionServiceV2Client) {
@@ -149,7 +149,7 @@ func TestLogsDataPusher(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			exporter := tc.setupExporter()
-			tc.setupMocks(exporter.client.(*mocks.MockIngestionServiceV2Client))
+			tc.setupMocks(exporter.grpcClient.(*mocks.MockIngestionServiceV2Client))
 
 			// Create a dummy plog.Logs to pass to logsDataPusher
 			logs := mockLogs(mockLogRecord("Test body", map[string]any{"key1": "value1"}))

--- a/exporter/chronicleexporter/factory.go
+++ b/exporter/chronicleexporter/factory.go
@@ -86,6 +86,7 @@ func createLogsExporter(
 		exporterhelper.WithTimeout(chronicleCfg.TimeoutConfig),
 		exporterhelper.WithQueue(chronicleCfg.QueueConfig),
 		exporterhelper.WithRetry(chronicleCfg.BackOffConfig),
+		exporterhelper.WithStart(exp.Start),
 		exporterhelper.WithShutdown(exp.Shutdown),
 	)
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change

While testing another fix by spinning up a chronicle exporter, sending a log to Chronicle, and then shutting down the exporter, I encountered this error:

![image](https://github.com/user-attachments/assets/d73b3967-6ca5-4273-ab68-fc265f9508a7)

I was understandably confused, so asked for help from Dan Jaglowski, and he figured it out and came up with this solution after hours, along with some other refactors. Explanation and fix are all his, I'm just opening the PR.

To fix this, the Shutdown function actually needs to be:
```go
func (ce *chronicleExporter) Shutdown(context.Context) error {
	if ce.cfg.Protocol == protocolHTTPS {
		t := ce.httpClient.Transport.(*oauth2.Transport)
		if t.Base != nil {
			t.Base.(*http.Transport).CloseIdleConnections()
		} else {
			http.DefaultTransport.(*http.Transport).CloseIdleConnections()
		}
		return nil
	}

	ce.cancel()
	ce.wg.Wait()
	if ce.grpcConn != nil {
		if err := ce.grpcConn.Close(); err != nil {
			return fmt.Errorf("connection close: %s", err)
		}
	}
	return nil
}
```

Larger explanation:

In Start, when we instantiate the httpClient : ce.httpClient = oauth2.NewClient(context.Background(), creds.TokenSource) , it doesn't actually matter what context we pass in. It isn't used for cancelation.

What we get back is always an *http.Client that contains a Transport field of type *oauth2.Transport. This in turn always contains a Base that is nil, which means it will use http.DefaultTransport. The thing with http.DefaultTransport (as well as many others) is that they will reuse connections by setting them into a "keep alive" state. The only way to clean these up is to call CloseIdleConnections() on the Transport. However, because we're getting an *oauth2.Transport that doesn't itself contain a CloseIdleConnections() method, we have to to access the http.DefaultTransport directly and call CloseIdleConnections() on it.

If you would like a test case to reproduce this, please contact me for one - not sure we have one that doesn't involve actually sending data to Chronicle.

<!-- Please provide a description of the change here. -->

##### Checklist
- [X] Changes are tested
- [X] CI has passed