### PR TITLE
fix: Delete empty values iterates through nested arrays

### DIFF
--- a/processor/removeemptyvaluesprocessor/processor.go
+++ b/processor/removeemptyvaluesprocessor/processor.go
@@ -16,6 +16,7 @@ package removeemptyvaluesprocessor
 
 import (
 	"context"
+
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -298,6 +299,7 @@ func cleanLogBody(lr plog.LogRecord, c Config, keys map[string]struct{}) {
 		}
 	case pcommon.ValueTypeSlice:
 		bodySlice := body.Slice()
+		cleanSlice(bodySlice, c, keys)
 		if c.RemoveEmptyLists && bodySlice.Len() == 0 {
 			pcommon.NewValueEmpty().CopyTo(body)
 		}


### PR DESCRIPTION
### Proposed Change
- Added implementation for iterating through slices in telemetry
- Cleans value depending on value in array, whether empty, map, slice,  or str.
- Add unit tests to handle

###
Testing
- Unit testing
- Test agent locally in bp to see proper processor behavior

### Logs sent in
<img width="862" alt="image" src="https://github.com/user-attachments/assets/0fab6a16-c938-4741-a0ad-0d3187456595">
### Result seen in recent telemetry
<img width="1482" alt="image" src="https://github.com/user-attachments/assets/adcc3627-5c2a-440e-9609-f75f6eae20e1">

